### PR TITLE
Fix Content-Type to not check for exact match for application/xml

### DIFF
--- a/spekev2_verification_testsuite/.gitignore
+++ b/spekev2_verification_testsuite/.gitignore
@@ -1,0 +1,2 @@
+.pytest_cache
+reports

--- a/spekev2_verification_testsuite/test_basic_checks.py
+++ b/spekev2_verification_testsuite/test_basic_checks.py
@@ -15,8 +15,14 @@ def test_status_code(basic_response):
     assert basic_response.status_code == 200 
 
 def test_speke_v2_headers(basic_response):
-    assert basic_response.headers.get('Content-Type') == 'application/xml', \
-    "Content-Type must be application/xml"
+    content_type = basic_response.headers.get('Content-Type').lower()
+    assert 'application/xml' in  content_type, \
+    "Content-Type must contain application/xml"
+
+    if 'charset' in content_type:
+        assert 'charset=utf-8' in content_type, \
+        "Charset value, if present, must be 'utf-8'"
+
     assert basic_response.headers.get('X-Speke-Version') == '2.0', \
     "X-Speke-Version must be 2.0"
     assert basic_response.headers.get('X-Speke-User-Agent'), \


### PR DESCRIPTION
Description of changes:
`Content-Type` need not exactly match with `application/xml`
`charset` value must be utf-8 if present in Content-Type

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
