### PR TITLE
Fix test suite bugs and relax some requirements

### DIFF
--- a/spekev2_verification_testsuite/spekev2_requests/test_case_1_p_v_1_a_1/1_widevine.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_1_p_v_1_a_1/1_widevine.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="abc123" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
+<cpix:CPIX contentId="test_case_1" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
                          commonEncryptionScheme="cenc">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_1_p_v_1_a_1/2_playready.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_1_p_v_1_a_1/2_playready.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="abc123" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
+<cpix:CPIX contentId="test_case_1" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
                          commonEncryptionScheme="cenc">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_1_p_v_1_a_1/3_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_1_p_v_1_a_1/3_fairplay.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="abc123" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
+<cpix:CPIX contentId="test_case_1" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
                          commonEncryptionScheme="cbcs">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_1_p_v_1_a_1/4_widevine_playready.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_1_p_v_1_a_1/4_widevine_playready.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="abc123" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
+<cpix:CPIX contentId="test_case_1" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
                          commonEncryptionScheme="cenc">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_1_p_v_1_a_1/5_widevine_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_1_p_v_1_a_1/5_widevine_fairplay.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="abc123" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
+<cpix:CPIX contentId="test_case_1" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
                          commonEncryptionScheme="cbcs">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_1_p_v_1_a_1/6_playready_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_1_p_v_1_a_1/6_playready_fairplay.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="abc123" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
+<cpix:CPIX contentId="test_case_1" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
                          commonEncryptionScheme="cbcs">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_1_p_v_1_a_1/7_widevine_playready_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_1_p_v_1_a_1/7_widevine_playready_fairplay.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="abc123" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
+<cpix:CPIX contentId="test_case_1" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
                          commonEncryptionScheme="cbcs">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/1_widevine.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/1_widevine.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="abc123" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
+<cpix:CPIX contentId="test_case_2" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
                          commonEncryptionScheme="cenc">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/2_playready.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/2_playready.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="abc123" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
+<cpix:CPIX contentId="test_case_2" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
                          commonEncryptionScheme="cenc">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/3_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/3_fairplay.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="abc123" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
+<cpix:CPIX contentId="test_case_2" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
                          commonEncryptionScheme="cbcs">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/4_widevine_playready.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/4_widevine_playready.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="abc123" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
+<cpix:CPIX contentId="test_case_2" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
                          commonEncryptionScheme="cenc">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/5_widevine_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/5_widevine_fairplay.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="abc123" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
+<cpix:CPIX contentId="test_case_2" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
                          commonEncryptionScheme="cbcs">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/6_playready_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/6_playready_fairplay.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="abc123" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
+<cpix:CPIX contentId="test_case_2" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
-                         commonEncryptionScheme="cenc">
+                         commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
         <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
-                         commonEncryptionScheme="cenc">
+                         commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
         <cpix:ContentKey kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce"
-                         commonEncryptionScheme="cenc">
+                         commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
         <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
-                         commonEncryptionScheme="cenc">
+                         commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
         <cpix:ContentKey kid="80969196-fe0d-4c1b-aec3-522bebcbd61c"
-                         commonEncryptionScheme="cenc">
+                         commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/7_widevine_playready_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/7_widevine_playready_fairplay.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="abc123" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
+<cpix:CPIX contentId="test_case_2" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
-                         commonEncryptionScheme="cenc">
+                         commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
         <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
-                         commonEncryptionScheme="cenc">
+                         commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
         <cpix:ContentKey kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce"
-                         commonEncryptionScheme="cenc">
+                         commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
         <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
-                         commonEncryptionScheme="cenc">
+                         commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
         <cpix:ContentKey kid="80969196-fe0d-4c1b-aec3-522bebcbd61c"
-                         commonEncryptionScheme="cenc">
+                         commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/1_widevine.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/1_widevine.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="abc123" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
+<cpix:CPIX contentId="test_case_3" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
            xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/2_playready.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/2_playready.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="abc123" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
+<cpix:CPIX contentId="test_case_3" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
                          commonEncryptionScheme="cenc">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/3_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/3_fairplay.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="abc123" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
+<cpix:CPIX contentId="test_case_3" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
                          commonEncryptionScheme="cbcs">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/4_widevine_playready.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/4_widevine_playready.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="abc123" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
+<cpix:CPIX contentId="test_case_3" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
            xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/5_widevine_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/5_widevine_fairplay.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="abc123" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
+<cpix:CPIX contentId="test_case_3" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
            xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/6_playready_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/6_playready_fairplay.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="abc123" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
+<cpix:CPIX contentId="test_case_3" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
            xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/7_widevine_playready_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/7_widevine_playready_fairplay.xml
@@ -1,30 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="abc123" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
+<cpix:CPIX contentId="test_case_3" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
            xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
-                         commonEncryptionScheme="cenc">
+                         commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
         <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
-                         commonEncryptionScheme="cenc">
+                         commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
         <cpix:ContentKey kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce"
-                         commonEncryptionScheme="cenc">
+                         commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
         <cpix:ContentKey kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01"
-                         commonEncryptionScheme="cenc">
+                         commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
         <cpix:ContentKey kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d"
-                         commonEncryptionScheme="cenc">
+                         commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
         <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
-                         commonEncryptionScheme="cenc">
+                         commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
         <cpix:ContentKey kid="80969196-fe0d-4c1b-aec3-522bebcbd61c"
-                         commonEncryptionScheme="cenc">
+                         commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
         <cpix:ContentKey kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0"
-                         commonEncryptionScheme="cenc">
+                         commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/1_widevine.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/1_widevine.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="abc123" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
+<cpix:CPIX contentId="test_case_4" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
            xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/2_playready.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/2_playready.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="abc123" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
+<cpix:CPIX contentId="test_case_4" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
            xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/3_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/3_fairplay.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="abc123" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
+<cpix:CPIX contentId="test_case_4" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
            xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/4_widevine_playready.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/4_widevine_playready.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="abc123" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
+<cpix:CPIX contentId="test_case_4" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
            xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/5_widevine_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/5_widevine_fairplay.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="abc123" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
+<cpix:CPIX contentId="test_case_4" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
            xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
-                         commonEncryptionScheme="cenc">
+                         commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
         <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
-                         commonEncryptionScheme="cenc">
+                         commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
         <cpix:ContentKey kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce"
-                         commonEncryptionScheme="cenc">
+                         commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
         <cpix:ContentKey kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01"
-                         commonEncryptionScheme="cenc">
+                         commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
         <cpix:ContentKey kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d"
-                         commonEncryptionScheme="cenc">
+                         commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
         <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
-                         commonEncryptionScheme="cenc">
+                         commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/6_playready_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/6_playready_fairplay.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="abc123" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
+<cpix:CPIX contentId="test_case_4" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
            xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/7_widevine_playready_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/7_widevine_playready_fairplay.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="abc123" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
+<cpix:CPIX contentId="test_case_4" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
            xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"

--- a/spekev2_verification_testsuite/test_basic_checks.py
+++ b/spekev2_verification_testsuite/test_basic_checks.py
@@ -82,11 +82,17 @@ def test_speke_v2_elements_have_not_changed(basic_response):
         assert content_key_usage_rule_element.get('intendedTrackType') in utils.SPEKE_V2_SUPPORTED_INTENDED_TRACK_TYPES, \
             f"intendedTrackType value must be one of {utils.SPEKE_V2_SUPPORTED_INTENDED_TRACK_TYPES}"
 
+
 def test_sending_same_request_sent_twice_to_keyserver_without_key_rotation(duplicate_responses):
+    test_responses = [response.replace("\n", "").replace("\r", "") for response in duplicate_responses]
     regex_pattern = "<pskc:PlainValue>(.*)</pskc:PlainValue>(.*)<pskc:PlainValue>(.*)</pskc:PlainValue>"
     results = []
-    for response in duplicate_responses:
+    for response in test_responses:
         results.append(re.search(regex_pattern, response))
 
-    assert results[0].group(1) == results[1].group(1) and results[0].group(3) == results[1].group(3), \
-        "Keys returned for duplicate responses must be the same with key rotation turned off"
+    if results[0] is not None:
+        assert results[0].group(1) == results[1].group(1) and results[0].group(3) == results[1].group(3), \
+            "Keys returned for duplicate responses must be the same with key rotation turned off"
+    else:
+        assert False, \
+            "Pattern matching failed"

--- a/spekev2_verification_testsuite/test_case_3_preset_video_5_preset_audio_3.py
+++ b/spekev2_verification_testsuite/test_case_3_preset_video_5_preset_audio_3.py
@@ -101,7 +101,7 @@ def test_case_3_playready_fairplay(playready_fairplay_response):
     speke_element_assertions.validate_mandatory_cpix_child_elements(root_cpix)
     speke_element_assertions.validate_content_key_list_element(root_cpix, 8, "cbcs")
     speke_element_assertions.validate_drm_system_list_element(root_cpix, 16, 8, 0, 8, 8)
-    speke_element_assertions.validate_content_key_usage_rule_list_element(root_cpix, 5)
+    speke_element_assertions.validate_content_key_usage_rule_list_element(root_cpix, 8)
 
 
 def test_case_3_widevine_playready_fairplay(widevine_playready_fairplay_response):

--- a/spekev2_verification_testsuite/test_drm_system_specific_system_id_elements.py
+++ b/spekev2_verification_testsuite/test_drm_system_specific_system_id_elements.py
@@ -125,8 +125,11 @@ def test_playready_pssh_hlssignalingdata_no_rotation(playready_pssh_hlssignaling
             "KEYFORMAT for #EXT-X-KEY and EXT-X-SESSION-KEY must match for this request"
         assert str_ext_x_key.keys[0].keyformatversions == str_ext_x_session_key.keys[0].keyformatversions, \
             "KEYFORMATVERSIONS for #EXT-X-KEY and EXT-X-SESSION-KEY must match for this request"
-        assert str_ext_x_key.keys[0].uri == str_ext_x_session_key.keys[0].uri, \
-            "URI for #EXT-X-KEY and EXT-X-SESSION-KEY must match for this request"
+
+        # Relaxing this requirement, this was originally added as we do not currently support different values
+        # for the two signaling levels.
+        # assert str_ext_x_key.keys[0].uri == str_ext_x_session_key.keys[0].uri, \
+        #     "URI for #EXT-X-KEY and EXT-X-SESSION-KEY must match for this request"
 
         assert str_ext_x_key.keys[0].keyformat == str_ext_x_session_key.keys[
             0].keyformat == utils.HLS_SIGNALING_DATA_KEYFORMAT.get("playready"), \

--- a/spekev2_verification_testsuite/test_negative_cases.py
+++ b/spekev2_verification_testsuite/test_negative_cases.py
@@ -50,7 +50,6 @@ def test_mandatory_elements_missing_in_request(spekev2_url, generic_request, man
         f"Mandatory element: {mandatory_element} not present in request but response was a 200 OK"
 
 
-@pytest.mark.skip(reason="We don't use these 2 filters currently even if they're present in request")
 def test_both_mandatory_filter_elements_missing_in_request(spekev2_url, generic_request):
     request_cpix = ET.fromstring(generic_request)
     for node in request_cpix.iter():

--- a/spekev2_verification_testsuite/test_negative_cases.py
+++ b/spekev2_verification_testsuite/test_negative_cases.py
@@ -50,6 +50,7 @@ def test_mandatory_elements_missing_in_request(spekev2_url, generic_request, man
         f"Mandatory element: {mandatory_element} not present in request but response was a 200 OK"
 
 
+@pytest.mark.skip(reason="We don't use these 2 filters currently even if they're present in request")
 def test_both_mandatory_filter_elements_missing_in_request(spekev2_url, generic_request):
     request_cpix = ET.fromstring(generic_request)
     for node in request_cpix.iter():


### PR DESCRIPTION
*Description of changes:*
- Rename ContentID for test xml requests
- Fix a check looking for 5 ContentKey elements instead of 8
- Relax requirements of media and master elements of HLSSignaling URI being same


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
