### PR TITLE
Add more tests for Speke v2 SHARED and UNENCRYPTED presets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ __pycache__/
 .vscode/
 build/
 env/
+.idea/
+Pipfile
+reports/

--- a/spekev2_verification_testsuite/helpers/speke_element_assertions.py
+++ b/spekev2_verification_testsuite/helpers/speke_element_assertions.py
@@ -9,6 +9,17 @@ def check_cpix_version(root):
         "Attribute: version value for CPIX element is expected to be 2.3"
 
 
+def validate_spekev2_response_headers(root):
+    """
+        Check X-Speke-Version and X-Speke-User-Agent in the headers
+    """
+
+    assert root.headers.get('X-Speke-Version') == '2.0', \
+        "X-Speke-Version must be 2.0"
+    assert root.headers.get('X-Speke-User-Agent'), \
+        "X-Speke-User-Agent must be present in the response"
+
+
 def validate_root_element(root_cpix):
     """
         1. Check CPIX tag exists

--- a/spekev2_verification_testsuite/helpers/utils.py
+++ b/spekev2_verification_testsuite/helpers/utils.py
@@ -19,12 +19,14 @@ WIDEVINE_PSSH_CPD_TEST_FILE = "7_spekev2_dash_widevine_preset_video_1_audio_1_no
 PLAYREADY_PSSH_CPD_TEST_FILE = "8_spekev2_dash_playready_preset_video_1_audio_1_no_rotation_pssh_cpd.xml"
 PLAYREADY_PSSH_HLSSIGNALINGDATA_TEST_FILE = "9_spekev2_dash_playready_preset_video_1_audio_1_no_rotation_pssh_signallingdata.xml"
 WRONG_VERSION_TEST_FILE = "4_negative_wrong_version_spekev2_dash_widevine.xml"  # Wrong CPIX version in request
+SPEKEV1_STYLE_REQUEST_WITH_SPEKEV2_HEADERS = "5_speke_v1_style_implementation.xml"
 
 # TEST CASES
 TEST_CASE_1_P_V_1_A_1 = "test_case_1_p_v_1_a_1"
 TEST_CASE_2_P_V_3_A_2 = "test_case_2_p_v_3_a_2"
 TEST_CASE_3_P_V_5_A_3 = "test_case_3_p_v_5_a_3"
 TEST_CASE_4_P_V_8_A_2 = "test_case_4_p_v_8_a_2"
+TEST_CASE_5_6_P_V_2_A_2 = "test_case_5_and_6_p_v_2_a_2"
 
 # PRESET TEST CASES FILE NAMES
 PRESETS_WIDEVINE = "1_widevine.xml"
@@ -134,6 +136,40 @@ def send_speke_request(test_xml_folder, test_xml_file, spekev2_url):
     test_request_data = read_xml_file_contents(test_xml_folder, test_xml_file)
     response = speke_v2_request(spekev2_url, test_request_data)
     return response.text
+
+
+def remove_element(xml_request, element_to_remove, kid_value = ""):
+    for node in xml_request.iter():
+        if not kid_value:
+            for child in node.findall(element_to_remove):
+                node.remove(child)
+        else:
+            for child in node.findall(element_to_remove):
+                if child.attrib.get("kid") == kid_value:
+                    node.remove(child)
+
+    return xml_request
+
+
+def send_modified_speke_request_with_element_removed(spekev2_url, xml_request_str, element_to_remove):
+    request_cpix = ET.fromstring(xml_request_str)
+    modified_cpix_request = remove_element(request_cpix, element_to_remove)
+    modified_cpix_request_str = ET.tostring(modified_cpix_request, method="xml")
+    response = speke_v2_request(spekev2_url, modified_cpix_request_str)
+    return response
+
+
+def send_modified_speke_request_with_matching_elements_kid_values_removed(spekev2_url, xml_request_str, elements_to_remove, kid_values):
+    request_cpix = ET.fromstring(xml_request_str)
+
+    for elem in elements_to_remove:
+        for kid in kid_values:
+            remove_element(request_cpix, elem, kid)
+
+    modified_cpix_request_str = ET.tostring(request_cpix, method="xml")
+
+    response = speke_v2_request(spekev2_url, modified_cpix_request_str)
+    return response
 
 
 def count_tags(xml_content):

--- a/spekev2_verification_testsuite/spekev2_requests/general/5_speke_v1_style_implementation.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/general/5_speke_v1_style_implementation.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cpix:CPIX contentId="cenc_test_001" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:enc="http://www.w3.org/2001/04/xmlenc#">
+    <cpix:ContentKeyList>
+        <cpix:ContentKey kid="0f083e4e-b831-4a3d-917e-ce78076e54aa" commonEncryptionScheme="cenc"></cpix:ContentKey>
+    </cpix:ContentKeyList>
+    <cpix:DRMSystemList>
+        <cpix:DRMSystem kid="0f083e4e-b831-4a3d-917e-ce78076e54aa" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+            <cpix:PSSH />
+            <cpix:ContentProtectionData />
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
+    </cpix:DRMSystemList>
+    <cpix:ContentKeyUsageRuleList>
+        <cpix:ContentKeyUsageRule kid="0f083e4e-b831-4a3d-917e-ce78076e54aa" intendedTrackType="ALL">
+            <cpix:VideoFilter />
+            <cpix:AudioFilter />
+        </cpix:ContentKeyUsageRule>
+    </cpix:ContentKeyUsageRuleList>
+</cpix:CPIX>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/1_widevine.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/1_widevine.xml
@@ -125,7 +125,7 @@
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3" maxChannels="6"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" intendedTrackType="MULTICHANNEL_AUDIO_7+">
+        <cpix:ContentKeyUsageRule kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" intendedTrackType="MULTICHANNEL_AUDIO_7">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="7"/>
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/4_widevine_playready.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/4_widevine_playready.xml
@@ -189,7 +189,7 @@
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3" maxChannels="6"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" intendedTrackType="MULTICHANNEL_AUDIO_7+">
+        <cpix:ContentKeyUsageRule kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" intendedTrackType="MULTICHANNEL_AUDIO_7">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="7"/>
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/5_widevine_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/5_widevine_fairplay.xml
@@ -173,7 +173,7 @@
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3" maxChannels="6"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" intendedTrackType="MULTICHANNEL_AUDIO_7+">
+        <cpix:ContentKeyUsageRule kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" intendedTrackType="MULTICHANNEL_AUDIO_7">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="7"/>
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/6_playready_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/6_playready_fairplay.xml
@@ -173,7 +173,7 @@
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3" maxChannels="6"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" intendedTrackType="MULTICHANNEL_AUDIO_7+">
+        <cpix:ContentKeyUsageRule kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" intendedTrackType="MULTICHANNEL_AUDIO_7">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="7"/>
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/7_widevine_playready_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/7_widevine_playready_fairplay.xml
@@ -237,7 +237,7 @@
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3" maxChannels="6"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" intendedTrackType="MULTICHANNEL_AUDIO_7+">
+        <cpix:ContentKeyUsageRule kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" intendedTrackType="MULTICHANNEL_AUDIO_7">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="7"/>
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/1_widevine.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/1_widevine.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cpix:CPIX contentId="test_case_5_6" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
+    <cpix:ContentKeyList>
+        <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
+                         commonEncryptionScheme="cenc">
+        </cpix:ContentKey>
+        <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+                         commonEncryptionScheme="cenc">
+        </cpix:ContentKey>
+        <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
+                         commonEncryptionScheme="cenc">
+        </cpix:ContentKey>
+        <cpix:ContentKey kid="80969196-fe0d-4c1b-aec3-522bebcbd61c"
+                         commonEncryptionScheme="cenc">
+        </cpix:ContentKey>
+    </cpix:ContentKeyList>
+    <cpix:DRMSystemList>
+        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+            <cpix:PSSH />
+            <cpix:ContentProtectionData />
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
+        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+            <cpix:PSSH />
+            <cpix:ContentProtectionData />
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
+        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+             <cpix:PSSH />
+            <cpix:ContentProtectionData />
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
+        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+             <cpix:PSSH />
+            <cpix:ContentProtectionData />
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
+    </cpix:DRMSystemList>
+    <cpix:ContentKeyPeriodList>
+        <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
+    </cpix:ContentKeyPeriodList>
+    <cpix:ContentKeyUsageRuleList>
+        <cpix:ContentKeyUsageRule kid="873f3740-2508-4a2d-94bc-9b0f86649251" intendedTrackType="SD">
+            <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
+            <cpix:VideoFilter maxPixels="589824" />
+        </cpix:ContentKeyUsageRule>
+        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD">
+            <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
+            <cpix:VideoFilter minPixels="589825" />
+        </cpix:ContentKeyUsageRule>
+        <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="STEREO_AUDIO">
+            <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
+            <cpix:AudioFilter maxChannels="2" />
+        </cpix:ContentKeyUsageRule>
+        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO">
+            <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
+            <cpix:AudioFilter minChannels="3" />
+        </cpix:ContentKeyUsageRule>
+    </cpix:ContentKeyUsageRuleList>
+</cpix:CPIX>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/2_playready.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/2_playready.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cpix:CPIX contentId="test_case_5_6" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
+    <cpix:ContentKeyList>
+        <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
+                         commonEncryptionScheme="cenc">
+        </cpix:ContentKey>
+        <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+                         commonEncryptionScheme="cenc">
+        </cpix:ContentKey>
+        <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
+                         commonEncryptionScheme="cenc">
+        </cpix:ContentKey>
+        <cpix:ContentKey kid="80969196-fe0d-4c1b-aec3-522bebcbd61c"
+                         commonEncryptionScheme="cenc">
+        </cpix:ContentKey>
+    </cpix:ContentKeyList>
+    <cpix:DRMSystemList>
+        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+            <cpix:PSSH />
+            <cpix:ContentProtectionData />
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
+        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+            <cpix:PSSH />
+            <cpix:ContentProtectionData />
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
+        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+             <cpix:PSSH />
+            <cpix:ContentProtectionData />
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
+        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+             <cpix:PSSH />
+            <cpix:ContentProtectionData />
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
+    </cpix:DRMSystemList>
+    <cpix:ContentKeyPeriodList>
+        <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
+    </cpix:ContentKeyPeriodList>
+    <cpix:ContentKeyUsageRuleList>
+        <cpix:ContentKeyUsageRule kid="873f3740-2508-4a2d-94bc-9b0f86649251" intendedTrackType="SD">
+            <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
+            <cpix:VideoFilter maxPixels="589824" />
+        </cpix:ContentKeyUsageRule>
+        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD">
+            <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
+            <cpix:VideoFilter minPixels="589825" />
+        </cpix:ContentKeyUsageRule>
+        <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="STEREO_AUDIO">
+            <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
+            <cpix:AudioFilter maxChannels="2" />
+        </cpix:ContentKeyUsageRule>
+        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO">
+            <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
+            <cpix:AudioFilter minChannels="3" />
+        </cpix:ContentKeyUsageRule>
+    </cpix:ContentKeyUsageRuleList>
+</cpix:CPIX>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/3_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/3_fairplay.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cpix:CPIX contentId="test_case_5_6" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
+    <cpix:ContentKeyList>
+        <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
+                         commonEncryptionScheme="cbcs">
+        </cpix:ContentKey>
+        <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+                         commonEncryptionScheme="cbcs">
+        </cpix:ContentKey>
+        <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
+                         commonEncryptionScheme="cbcs">
+        </cpix:ContentKey>
+        <cpix:ContentKey kid="80969196-fe0d-4c1b-aec3-522bebcbd61c"
+                         commonEncryptionScheme="cbcs">
+        </cpix:ContentKey>
+    </cpix:ContentKeyList>
+    <cpix:DRMSystemList>
+        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
+        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
+        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
+        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
+    </cpix:DRMSystemList>
+    <cpix:ContentKeyPeriodList>
+        <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
+    </cpix:ContentKeyPeriodList>
+    <cpix:ContentKeyUsageRuleList>
+        <cpix:ContentKeyUsageRule kid="873f3740-2508-4a2d-94bc-9b0f86649251" intendedTrackType="SD">
+            <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
+            <cpix:VideoFilter maxPixels="589824" />
+        </cpix:ContentKeyUsageRule>
+        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD">
+            <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
+            <cpix:VideoFilter minPixels="589825" />
+        </cpix:ContentKeyUsageRule>
+        <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="STEREO_AUDIO">
+            <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
+            <cpix:AudioFilter maxChannels="2" />
+        </cpix:ContentKeyUsageRule>
+        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO">
+            <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
+            <cpix:AudioFilter minChannels="3" />
+        </cpix:ContentKeyUsageRule>
+    </cpix:ContentKeyUsageRuleList>
+</cpix:CPIX>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/4_widevine_playready.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/4_widevine_playready.xml
@@ -1,19 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="test_case_3" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
+<cpix:CPIX contentId="test_case_5_6" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
         <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
-                         commonEncryptionScheme="cenc">
-        </cpix:ContentKey>
-        <cpix:ContentKey kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce"
-                         commonEncryptionScheme="cenc">
-        </cpix:ContentKey>
-        <cpix:ContentKey kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01"
-                         commonEncryptionScheme="cenc">
-        </cpix:ContentKey>
-        <cpix:ContentKey kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
         <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
@@ -22,11 +13,40 @@
         <cpix:ContentKey kid="80969196-fe0d-4c1b-aec3-522bebcbd61c"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0"
-                         commonEncryptionScheme="cenc">
-        </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
+        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+            <cpix:PSSH />
+            <cpix:ContentProtectionData />
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
+        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+            <cpix:PSSH />
+            <cpix:ContentProtectionData />
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
+        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+             <cpix:PSSH />
+            <cpix:ContentProtectionData />
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
+        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+             <cpix:PSSH />
+            <cpix:ContentProtectionData />
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
         <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
@@ -37,30 +57,6 @@
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH />
-            <cpix:ContentProtectionData />
-            <cpix:HLSSignalingData playlist="media">
-            </cpix:HLSSignalingData>
-            <cpix:HLSSignalingData playlist="master">
-            </cpix:HLSSignalingData>
-        </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
-             <cpix:PSSH />
-            <cpix:ContentProtectionData />
-            <cpix:HLSSignalingData playlist="media">
-            </cpix:HLSSignalingData>
-            <cpix:HLSSignalingData playlist="master">
-            </cpix:HLSSignalingData>
-        </cpix:DRMSystem>
-        <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
-             <cpix:PSSH />
-            <cpix:ContentProtectionData />
-            <cpix:HLSSignalingData playlist="media">
-            </cpix:HLSSignalingData>
-            <cpix:HLSSignalingData playlist="master">
-            </cpix:HLSSignalingData>
-        </cpix:DRMSystem>
-        <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
-             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
@@ -83,14 +79,6 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
-             <cpix:PSSH />
-            <cpix:ContentProtectionData />
-            <cpix:HLSSignalingData playlist="media">
-            </cpix:HLSSignalingData>
-            <cpix:HLSSignalingData playlist="master">
-            </cpix:HLSSignalingData>
-        </cpix:DRMSystem>
     </cpix:DRMSystemList>
     <cpix:ContentKeyPeriodList>
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
@@ -100,33 +88,17 @@
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="589824" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD1">
+        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
-            <cpix:VideoFilter minPixels="589825" maxPixels="921600" />
-        </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" intendedTrackType="HD2">
-            <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
-            <cpix:VideoFilter minPixels="921601" maxPixels="2073600" />
-        </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" intendedTrackType="UHD1">
-            <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
-            <cpix:VideoFilter minPixels="2073601" maxPixels="8847360" />
-        </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" intendedTrackType="UHD2">
-            <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
-            <cpix:VideoFilter minPixels="8847361" />
+            <cpix:VideoFilter minPixels="589825" />
         </cpix:ContentKeyUsageRule>
         <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO_3_6">
+        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
-            <cpix:AudioFilter minChannels="3" maxChannels="6" />
-        </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" intendedTrackType="MULTICHANNEL_AUDIO_7">
-            <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
-            <cpix:AudioFilter minChannels="7" />
+            <cpix:AudioFilter minChannels="3" />
         </cpix:ContentKeyUsageRule>
     </cpix:ContentKeyUsageRuleList>
 </cpix:CPIX>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/5_widevine_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/5_widevine_fairplay.xml
@@ -1,19 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="test_case_3" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
+<cpix:CPIX contentId="test_case_5_6" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
         <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
-                         commonEncryptionScheme="cbcs">
-        </cpix:ContentKey>
-        <cpix:ContentKey kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce"
-                         commonEncryptionScheme="cbcs">
-        </cpix:ContentKey>
-        <cpix:ContentKey kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01"
-                         commonEncryptionScheme="cbcs">
-        </cpix:ContentKey>
-        <cpix:ContentKey kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
         <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
@@ -22,11 +13,40 @@
         <cpix:ContentKey kid="80969196-fe0d-4c1b-aec3-522bebcbd61c"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0"
-                         commonEncryptionScheme="cbcs">
-        </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
+        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+            <cpix:PSSH />
+            <cpix:ContentProtectionData />
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
+        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+            <cpix:PSSH />
+            <cpix:ContentProtectionData />
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
+        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+             <cpix:PSSH />
+            <cpix:ContentProtectionData />
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
+        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+             <cpix:PSSH />
+            <cpix:ContentProtectionData />
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
         <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
@@ -34,24 +54,6 @@
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
-            <cpix:HLSSignalingData playlist="media">
-            </cpix:HLSSignalingData>
-            <cpix:HLSSignalingData playlist="master">
-            </cpix:HLSSignalingData>
-        </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
-            <cpix:HLSSignalingData playlist="media">
-            </cpix:HLSSignalingData>
-            <cpix:HLSSignalingData playlist="master">
-            </cpix:HLSSignalingData>
-        </cpix:DRMSystem>
-        <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
-            <cpix:HLSSignalingData playlist="media">
-            </cpix:HLSSignalingData>
-            <cpix:HLSSignalingData playlist="master">
-            </cpix:HLSSignalingData>
-        </cpix:DRMSystem>
-        <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
@@ -69,12 +71,6 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
-            <cpix:HLSSignalingData playlist="media">
-            </cpix:HLSSignalingData>
-            <cpix:HLSSignalingData playlist="master">
-            </cpix:HLSSignalingData>
-        </cpix:DRMSystem>
     </cpix:DRMSystemList>
     <cpix:ContentKeyPeriodList>
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
@@ -84,33 +80,17 @@
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="589824" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD1">
+        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
-            <cpix:VideoFilter minPixels="589825" maxPixels="921600" />
-        </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" intendedTrackType="HD2">
-            <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
-            <cpix:VideoFilter minPixels="921601" maxPixels="2073600" />
-        </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" intendedTrackType="UHD1">
-            <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
-            <cpix:VideoFilter minPixels="2073601" maxPixels="8847360" />
-        </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" intendedTrackType="UHD2">
-            <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
-            <cpix:VideoFilter minPixels="8847361" />
+            <cpix:VideoFilter minPixels="589825" maxPixels="2073600" />
         </cpix:ContentKeyUsageRule>
         <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO_3_6">
+        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
-            <cpix:AudioFilter minChannels="3" maxChannels="6" />
-        </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" intendedTrackType="MULTICHANNEL_AUDIO_7">
-            <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
-            <cpix:AudioFilter minChannels="7" />
+            <cpix:AudioFilter minChannels="3" />
         </cpix:ContentKeyUsageRule>
     </cpix:ContentKeyUsageRuleList>
 </cpix:CPIX>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/6_playready_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/6_playready_fairplay.xml
@@ -1,19 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="test_case_3" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
+<cpix:CPIX contentId="test_case_5_6" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
         <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
-                         commonEncryptionScheme="cbcs">
-        </cpix:ContentKey>
-        <cpix:ContentKey kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce"
-                         commonEncryptionScheme="cbcs">
-        </cpix:ContentKey>
-        <cpix:ContentKey kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01"
-                         commonEncryptionScheme="cbcs">
-        </cpix:ContentKey>
-        <cpix:ContentKey kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
         <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
@@ -22,11 +13,40 @@
         <cpix:ContentKey kid="80969196-fe0d-4c1b-aec3-522bebcbd61c"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0"
-                         commonEncryptionScheme="cbcs">
-        </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
+        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+            <cpix:PSSH />
+            <cpix:ContentProtectionData />
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
+        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+            <cpix:PSSH />
+            <cpix:ContentProtectionData />
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
+        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+             <cpix:PSSH />
+            <cpix:ContentProtectionData />
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
+        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+            <cpix:PSSH />
+            <cpix:ContentProtectionData />
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
         <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
@@ -34,24 +54,6 @@
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
-            <cpix:HLSSignalingData playlist="media">
-            </cpix:HLSSignalingData>
-            <cpix:HLSSignalingData playlist="master">
-            </cpix:HLSSignalingData>
-        </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
-            <cpix:HLSSignalingData playlist="media">
-            </cpix:HLSSignalingData>
-            <cpix:HLSSignalingData playlist="master">
-            </cpix:HLSSignalingData>
-        </cpix:DRMSystem>
-        <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
-            <cpix:HLSSignalingData playlist="media">
-            </cpix:HLSSignalingData>
-            <cpix:HLSSignalingData playlist="master">
-            </cpix:HLSSignalingData>
-        </cpix:DRMSystem>
-        <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
@@ -69,12 +71,6 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
-            <cpix:HLSSignalingData playlist="media">
-            </cpix:HLSSignalingData>
-            <cpix:HLSSignalingData playlist="master">
-            </cpix:HLSSignalingData>
-        </cpix:DRMSystem>
     </cpix:DRMSystemList>
     <cpix:ContentKeyPeriodList>
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
@@ -84,33 +80,17 @@
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="589824" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD1">
+        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
-            <cpix:VideoFilter minPixels="589825" maxPixels="921600" />
-        </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" intendedTrackType="HD2">
-            <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
-            <cpix:VideoFilter minPixels="921601" maxPixels="2073600" />
-        </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" intendedTrackType="UHD1">
-            <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
-            <cpix:VideoFilter minPixels="2073601" maxPixels="8847360" />
-        </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" intendedTrackType="UHD2">
-            <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
-            <cpix:VideoFilter minPixels="8847361" />
+            <cpix:VideoFilter minPixels="589825" />
         </cpix:ContentKeyUsageRule>
         <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO_3_6">
+        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
-            <cpix:AudioFilter minChannels="3" maxChannels="6" />
-        </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" intendedTrackType="MULTICHANNEL_AUDIO_7">
-            <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
-            <cpix:AudioFilter minChannels="7" />
+            <cpix:AudioFilter minChannels="3" />
         </cpix:ContentKeyUsageRule>
     </cpix:ContentKeyUsageRuleList>
 </cpix:CPIX>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/7_widevine_playready_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/7_widevine_playready_fairplay.xml
@@ -1,19 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="test_case_3" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
+<cpix:CPIX contentId="test_case_5_6" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
         <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
         <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
-                         commonEncryptionScheme="cbcs">
-        </cpix:ContentKey>
-        <cpix:ContentKey kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce"
-                         commonEncryptionScheme="cbcs">
-        </cpix:ContentKey>
-        <cpix:ContentKey kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01"
-                         commonEncryptionScheme="cbcs">
-        </cpix:ContentKey>
-        <cpix:ContentKey kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
         <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
@@ -22,11 +13,72 @@
         <cpix:ContentKey kid="80969196-fe0d-4c1b-aec3-522bebcbd61c"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0"
-                         commonEncryptionScheme="cbcs">
-        </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
+        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+            <cpix:PSSH />
+            <cpix:ContentProtectionData />
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
+        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+            <cpix:PSSH />
+            <cpix:ContentProtectionData />
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
+        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+             <cpix:PSSH />
+            <cpix:ContentProtectionData />
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
+        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+             <cpix:PSSH />
+            <cpix:ContentProtectionData />
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
+        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+            <cpix:PSSH />
+            <cpix:ContentProtectionData />
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
+        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+            <cpix:PSSH />
+            <cpix:ContentProtectionData />
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
+        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+             <cpix:PSSH />
+            <cpix:ContentProtectionData />
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
+        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+            <cpix:PSSH />
+            <cpix:ContentProtectionData />
+            <cpix:HLSSignalingData playlist="media">
+            </cpix:HLSSignalingData>
+            <cpix:HLSSignalingData playlist="master">
+            </cpix:HLSSignalingData>
+        </cpix:DRMSystem>
         <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
@@ -34,24 +86,6 @@
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
-            <cpix:HLSSignalingData playlist="media">
-            </cpix:HLSSignalingData>
-            <cpix:HLSSignalingData playlist="master">
-            </cpix:HLSSignalingData>
-        </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
-            <cpix:HLSSignalingData playlist="media">
-            </cpix:HLSSignalingData>
-            <cpix:HLSSignalingData playlist="master">
-            </cpix:HLSSignalingData>
-        </cpix:DRMSystem>
-        <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
-            <cpix:HLSSignalingData playlist="media">
-            </cpix:HLSSignalingData>
-            <cpix:HLSSignalingData playlist="master">
-            </cpix:HLSSignalingData>
-        </cpix:DRMSystem>
-        <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
@@ -69,12 +103,6 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
-            <cpix:HLSSignalingData playlist="media">
-            </cpix:HLSSignalingData>
-            <cpix:HLSSignalingData playlist="master">
-            </cpix:HLSSignalingData>
-        </cpix:DRMSystem>
     </cpix:DRMSystemList>
     <cpix:ContentKeyPeriodList>
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
@@ -84,33 +112,17 @@
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="589824" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD1">
+        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
-            <cpix:VideoFilter minPixels="589825" maxPixels="921600" />
-        </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" intendedTrackType="HD2">
-            <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
-            <cpix:VideoFilter minPixels="921601" maxPixels="2073600" />
-        </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" intendedTrackType="UHD1">
-            <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
-            <cpix:VideoFilter minPixels="2073601" maxPixels="8847360" />
-        </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" intendedTrackType="UHD2">
-            <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
-            <cpix:VideoFilter minPixels="8847361" />
+            <cpix:VideoFilter minPixels="589825" />
         </cpix:ContentKeyUsageRule>
         <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO_3_6">
+        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
-            <cpix:AudioFilter minChannels="3" maxChannels="6" />
-        </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" intendedTrackType="MULTICHANNEL_AUDIO_7">
-            <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
-            <cpix:AudioFilter minChannels="7" />
+            <cpix:AudioFilter minChannels="3" />
         </cpix:ContentKeyUsageRule>
     </cpix:ContentKeyUsageRuleList>
 </cpix:CPIX>

--- a/spekev2_verification_testsuite/test_case_4_preset_video_8_preset_audio_2.py
+++ b/spekev2_verification_testsuite/test_case_4_preset_video_8_preset_audio_2.py
@@ -38,7 +38,7 @@ def widevine_playready_fairplay_response(spekev2_url):
     return utils.send_speke_request(utils.TEST_CASE_4_P_V_8_A_2, utils.PRESETS_WIDEVINE_PLAYREADY_FAIRPLAY, spekev2_url)
 
 
-def test_case_2_widevine(widevine_response):
+def test_case_4_widevine(widevine_response):
     root_cpix = ET.fromstring(widevine_response)
 
     speke_element_assertions.check_cpix_version(root_cpix)
@@ -49,7 +49,7 @@ def test_case_2_widevine(widevine_response):
     speke_element_assertions.validate_content_key_usage_rule_list_element(root_cpix, 6)
 
 
-def test_case_2_playready(playready_response):
+def test_case_4_playready(playready_response):
     root_cpix = ET.fromstring(playready_response)
 
     speke_element_assertions.check_cpix_version(root_cpix)
@@ -60,7 +60,7 @@ def test_case_2_playready(playready_response):
     speke_element_assertions.validate_content_key_usage_rule_list_element(root_cpix, 6)
 
 
-def test_case_2_fairplay(fairplay_response):
+def test_case_4_fairplay(fairplay_response):
     root_cpix = ET.fromstring(fairplay_response)
 
     speke_element_assertions.check_cpix_version(root_cpix)
@@ -71,7 +71,7 @@ def test_case_2_fairplay(fairplay_response):
     speke_element_assertions.validate_content_key_usage_rule_list_element(root_cpix, 6)
 
 
-def test_case_2_widevine_playready(widevine_playready_response):
+def test_case_4_widevine_playready(widevine_playready_response):
     root_cpix = ET.fromstring(widevine_playready_response)
 
     speke_element_assertions.check_cpix_version(root_cpix)
@@ -82,7 +82,7 @@ def test_case_2_widevine_playready(widevine_playready_response):
     speke_element_assertions.validate_content_key_usage_rule_list_element(root_cpix, 6)
 
 
-def test_case_2_widevine_fairplay(widevine_fairplay_response):
+def test_case_4_widevine_fairplay(widevine_fairplay_response):
     root_cpix = ET.fromstring(widevine_fairplay_response)
 
     speke_element_assertions.check_cpix_version(root_cpix)
@@ -93,7 +93,7 @@ def test_case_2_widevine_fairplay(widevine_fairplay_response):
     speke_element_assertions.validate_content_key_usage_rule_list_element(root_cpix, 6)
 
 
-def test_case_2_playready_fairplay(playready_fairplay_response):
+def test_case_4_playready_fairplay(playready_fairplay_response):
     root_cpix = ET.fromstring(playready_fairplay_response)
 
     speke_element_assertions.check_cpix_version(root_cpix)
@@ -104,7 +104,7 @@ def test_case_2_playready_fairplay(playready_fairplay_response):
     speke_element_assertions.validate_content_key_usage_rule_list_element(root_cpix, 6)
 
 
-def test_case_2_widevine_playready_fairplay(widevine_playready_fairplay_response):
+def test_case_4_widevine_playready_fairplay(widevine_playready_fairplay_response):
     root_cpix = ET.fromstring(widevine_playready_fairplay_response)
 
     speke_element_assertions.check_cpix_version(root_cpix)

--- a/spekev2_verification_testsuite/test_case_5_and_6_preset_2_unencrypted.py
+++ b/spekev2_verification_testsuite/test_case_5_and_6_preset_2_unencrypted.py
@@ -1,0 +1,176 @@
+import pytest
+from .helpers import utils, speke_element_assertions
+import xml.etree.ElementTree as ET
+
+elements_to_remove = [
+    "{urn:dashif:org:cpix}ContentKey",
+    "{urn:dashif:org:cpix}DRMSystem",
+    "{urn:dashif:org:cpix}ContentKeyUsageRule"
+]
+
+video_kid = [
+    "873f3740-2508-4a2d-94bc-9b0f86649251",
+    "0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+]
+
+audio_kid = [
+    "f8a6640e-2938-45b1-a1ba-2b203c51530c",
+    "80969196-fe0d-4c1b-aec3-522bebcbd61c"
+]
+
+
+@pytest.fixture(scope="session")
+def widevine_response(spekev2_url):
+    return utils.read_xml_file_contents(utils.TEST_CASE_5_6_P_V_2_A_2, utils.PRESETS_WIDEVINE)
+
+
+@pytest.fixture(scope="session")
+def playready_response(spekev2_url):
+    return utils.read_xml_file_contents(utils.TEST_CASE_5_6_P_V_2_A_2, utils.PRESETS_PLAYREADY)
+
+
+@pytest.fixture(scope="session")
+def fairplay_response(spekev2_url):
+    return utils.read_xml_file_contents(utils.TEST_CASE_5_6_P_V_2_A_2, utils.PRESETS_FAIRPLAY)
+
+
+@pytest.fixture(scope="session")
+def widevine_playready_response(spekev2_url):
+    return utils.read_xml_file_contents(utils.TEST_CASE_5_6_P_V_2_A_2, utils.PRESETS_WIDEVINE_PLAYREADY)
+
+
+@pytest.fixture(scope="session")
+def widevine_fairplay_response(spekev2_url):
+    return utils.read_xml_file_contents(utils.TEST_CASE_5_6_P_V_2_A_2, utils.PRESETS_WIDEVINE_FAIRPLAY)
+
+
+@pytest.fixture(scope="session")
+def playready_fairplay_response(spekev2_url):
+    return utils.read_xml_file_contents(utils.TEST_CASE_5_6_P_V_2_A_2, utils.PRESETS_PLAYREADY_FAIRPLAY)
+
+
+@pytest.fixture(scope="session")
+def widevine_playready_fairplay_response(spekev2_url):
+    return utils.read_xml_file_contents(utils.TEST_CASE_5_6_P_V_2_A_2, utils.PRESETS_WIDEVINE_PLAYREADY_FAIRPLAY)
+
+
+def test_case_5_widevine_preset_video_2_audio_unencrypted(widevine_response, spekev2_url):
+    xml_request = widevine_response.decode('UTF-8') \
+                    .replace("test_case_5_6", "test_case_5")
+    response = utils.send_modified_speke_request_with_matching_elements_kid_values_removed(spekev2_url,
+                                                                                           xml_request.encode("UTF-8"),
+                                                                                           elements_to_remove,
+                                                                                           audio_kid)
+
+
+    root_cpix = ET.fromstring(response.text)
+
+    speke_element_assertions.check_cpix_version(root_cpix)
+    speke_element_assertions.validate_root_element(root_cpix)
+    speke_element_assertions.validate_mandatory_cpix_child_elements(root_cpix)
+    speke_element_assertions.validate_content_key_list_element(root_cpix, 2, "cenc")
+    speke_element_assertions.validate_drm_system_list_element(root_cpix, 2, 2, 2, 0, 0)
+    speke_element_assertions.validate_content_key_usage_rule_list_element(root_cpix, 2)
+
+    # Check the audio kid values are not present in the response
+    assert response.text.find(audio_kid[0]) == -1 and response.text.find(audio_kid[1]) == -1
+
+
+def test_case_5_widevine_playready_preset_video_2_audio_unencrypted(widevine_playready_response, spekev2_url):
+    xml_request = widevine_playready_response.decode('UTF-8') \
+                    .replace("test_case_5_6", "test_case_5")
+    response = utils.send_modified_speke_request_with_matching_elements_kid_values_removed(spekev2_url,
+                                                                                           xml_request.encode("UTF-8"),
+                                                                                           elements_to_remove,
+                                                                                           audio_kid)
+    root_cpix = ET.fromstring(response.text)
+
+    speke_element_assertions.check_cpix_version(root_cpix)
+    speke_element_assertions.validate_root_element(root_cpix)
+    speke_element_assertions.validate_mandatory_cpix_child_elements(root_cpix)
+    speke_element_assertions.validate_content_key_list_element(root_cpix, 2, "cenc")
+    speke_element_assertions.validate_drm_system_list_element(root_cpix, 4, 2, 2, 2, 0)
+    speke_element_assertions.validate_content_key_usage_rule_list_element(root_cpix, 2)
+
+    # Check the audio kid values are not present in the response
+    assert response.text.find(audio_kid[0]) == -1 and response.text.find(audio_kid[1]) == -1
+
+
+def test_case_5_widevine_playready_fairplay_preset_video_2_audio_unencrypted(widevine_playready_fairplay_response, spekev2_url):
+    xml_request = widevine_playready_fairplay_response.decode('UTF-8') \
+        .replace("test_case_5_6", "test_case_5")
+    response = utils.send_modified_speke_request_with_matching_elements_kid_values_removed(spekev2_url,
+                                                                                           xml_request.encode("UTF-8"),
+                                                                                           elements_to_remove,
+                                                                                           audio_kid)
+    root_cpix = ET.fromstring(response.text)
+
+    speke_element_assertions.check_cpix_version(root_cpix)
+    speke_element_assertions.validate_root_element(root_cpix)
+    speke_element_assertions.validate_mandatory_cpix_child_elements(root_cpix)
+    speke_element_assertions.validate_content_key_list_element(root_cpix, 2, "cbcs")
+    speke_element_assertions.validate_drm_system_list_element(root_cpix, 6, 2, 2, 2, 2)
+    speke_element_assertions.validate_content_key_usage_rule_list_element(root_cpix, 2)
+
+    # Check the audio kid values are not present in the response
+    assert response.text.find(audio_kid[0]) == -1 and response.text.find(audio_kid[1]) == -1
+
+
+def test_case_6_widevine_video_unencrypted_preset_audio_2(widevine_response, spekev2_url):
+    xml_request = widevine_response.decode('UTF-8') \
+                    .replace("test_case_5_6", "test_case_6")
+    response = utils.send_modified_speke_request_with_matching_elements_kid_values_removed(spekev2_url,
+                                                                                           xml_request.encode("UTF-8"),
+                                                                                           elements_to_remove,
+                                                                                           video_kid)
+    root_cpix = ET.fromstring(response.text)
+
+    speke_element_assertions.check_cpix_version(root_cpix)
+    speke_element_assertions.validate_root_element(root_cpix)
+    speke_element_assertions.validate_mandatory_cpix_child_elements(root_cpix)
+    speke_element_assertions.validate_content_key_list_element(root_cpix, 2, "cenc")
+    speke_element_assertions.validate_drm_system_list_element(root_cpix, 2, 2, 2, 0, 0)
+    speke_element_assertions.validate_content_key_usage_rule_list_element(root_cpix, 2)
+
+    # Check the video kid values are not present in the response
+    assert response.text.find(video_kid[0]) == -1 and response.text.find(video_kid[1]) == -1
+
+
+def test_case_6_widevine_playready_video_unencrypted_preset_audio_2(widevine_playready_response, spekev2_url):
+    xml_request = widevine_playready_response.decode('UTF-8') \
+                    .replace("test_case_5_6", "test_case_6")
+    response = utils.send_modified_speke_request_with_matching_elements_kid_values_removed(spekev2_url,
+                                                                                           xml_request.encode("UTF-8"),
+                                                                                           elements_to_remove,
+                                                                                           video_kid)
+    root_cpix = ET.fromstring(response.text)
+
+    speke_element_assertions.check_cpix_version(root_cpix)
+    speke_element_assertions.validate_root_element(root_cpix)
+    speke_element_assertions.validate_mandatory_cpix_child_elements(root_cpix)
+    speke_element_assertions.validate_content_key_list_element(root_cpix, 2, "cenc")
+    speke_element_assertions.validate_drm_system_list_element(root_cpix, 4, 2, 2, 2, 0)
+    speke_element_assertions.validate_content_key_usage_rule_list_element(root_cpix, 2)
+
+    # Check the video kid values are not present in the response
+    assert response.text.find(video_kid[0]) == -1 and response.text.find(video_kid[1]) == -1
+
+
+def test_case_6_widevine_playready_fairplay_video_unencrypted_preset_audio_2(widevine_playready_fairplay_response, spekev2_url):
+    xml_request = widevine_playready_fairplay_response.decode('UTF-8') \
+                    .replace("test_case_5_6", "test_case_6")
+    response = utils.send_modified_speke_request_with_matching_elements_kid_values_removed(spekev2_url,
+                                                                                           xml_request.encode("UTF-8"),
+                                                                                           elements_to_remove,
+                                                                                           video_kid)
+    root_cpix = ET.fromstring(response.text)
+
+    speke_element_assertions.check_cpix_version(root_cpix)
+    speke_element_assertions.validate_root_element(root_cpix)
+    speke_element_assertions.validate_mandatory_cpix_child_elements(root_cpix)
+    speke_element_assertions.validate_content_key_list_element(root_cpix, 2, "cbcs")
+    speke_element_assertions.validate_drm_system_list_element(root_cpix, 6, 2, 2, 2, 2)
+    speke_element_assertions.validate_content_key_usage_rule_list_element(root_cpix, 2)
+
+    # Check the video kid values are not present in the response
+    assert response.text.find(video_kid[0]) == -1 and response.text.find(video_kid[1]) == -1

--- a/spekev2_verification_testsuite/test_drm_system_specific_system_id_elements.py
+++ b/spekev2_verification_testsuite/test_drm_system_specific_system_id_elements.py
@@ -137,7 +137,6 @@ def test_playready_pssh_hlssignalingdata_no_rotation(playready_pssh_hlssignaling
 
 
 def test_fairplay_hlssignalingdata_no_rotation(fairplay_hls_signalingdata_response):
-    print(fairplay_hls_signalingdata_response)
     root_cpix = ET.fromstring(fairplay_hls_signalingdata_response)
     drm_system_list_element = root_cpix.find('./{urn:dashif:org:cpix}DRMSystemList')
     drm_system_elements = drm_system_list_element.findall('./{urn:dashif:org:cpix}DRMSystem')

--- a/spekev2_verification_testsuite/test_negative_cases.py
+++ b/spekev2_verification_testsuite/test_negative_cases.py
@@ -14,6 +14,11 @@ def fairplay_request(spekev2_url):
 
 
 @pytest.fixture
+def preset_2_widevine_request(spekev2_url):
+    return utils.read_xml_file_contents(utils.TEST_CASE_5_6_P_V_2_A_2, utils.PRESETS_WIDEVINE)
+
+
+@pytest.fixture
 def empty_xml_response(spekev2_url):
     response = utils.speke_v2_request(spekev2_url, "")
     return response
@@ -38,14 +43,7 @@ def test_wrong_version_status_code(wrong_version_response):
 
 @pytest.mark.parametrize("mandatory_element", utils.SPEKE_V2_MANDATORY_ELEMENTS_LIST)
 def test_mandatory_elements_missing_in_request(spekev2_url, generic_request, mandatory_element):
-    request_cpix = ET.fromstring(generic_request)
-    for node in request_cpix.iter():
-        for child in node.findall(mandatory_element):
-            node.remove(child)
-
-    request_xml_data = ET.tostring(request_cpix, method="xml")
-    response = utils.speke_v2_request(spekev2_url, request_xml_data)
-
+    response = utils.send_modified_speke_request_with_element_removed(spekev2_url, generic_request, mandatory_element)
     assert response.status_code != 200 and (400 <= response.status_code < 600), \
         f"Mandatory element: {mandatory_element} not present in request but response was a 200 OK"
 
@@ -61,7 +59,8 @@ def test_both_mandatory_filter_elements_missing_in_request(spekev2_url, generic_
     response = utils.speke_v2_request(spekev2_url, request_xml_data)
 
     assert response.status_code != 200 and (400 <= response.status_code < 600), \
-        f"Mandatory filter elements: {utils.SPEKE_V2_MANDATORY_FILTER_ELEMENTS_LIST} not present in request but response was a 200 OK"
+        f"Mandatory filter elements: {utils.SPEKE_V2_MANDATORY_FILTER_ELEMENTS_LIST} not present in request but " \
+        f"response was a 200 OK "
 
 
 @pytest.mark.parametrize("mandatory_attribute", utils.SPEKE_V2_MANDATORY_ATTRIBUTES_LIST)
@@ -76,13 +75,46 @@ def test_missing_mandatory_attributes_in_request(spekev2_url, generic_request, m
     response = utils.speke_v2_request(spekev2_url, request_xml_data)
 
     assert response.status_code != 200 and (400 <= response.status_code < 600), \
-        f"Mandatory attribute(s): {mandatory_attribute[1]} for element: {mandatory_attribute[0]} not present in request but response was a 200 OK"
+        f"Mandatory attribute(s): {mandatory_attribute[1]} for element: {mandatory_attribute[0]} not present in " \
+        f"request but response was a 200 OK "
 
 
 def test_common_encryption_scheme_for_fairplay_should_not_be_cenc(spekev2_url, fairplay_request):
-    xml_request = str(fairplay_request).replace("cbcs", "cenc")
-    response = utils.speke_v2_request(spekev2_url, xml_request)
+    xml_request = fairplay_request.decode('UTF-8').replace("cbcs", "cenc")
+    response = utils.speke_v2_request(spekev2_url, xml_request.encode('UTF-8'))
 
     assert response.status_code != 200 and (400 <= response.status_code < 600), \
         f"Requests for Fairplay DRM system ID should not include cenc as common encryption. Status code returned was {response.status_code}"
 
+
+def test_video_preset_2_and_shared_audio_preset_request_expect_4xx(spekev2_url, preset_2_widevine_request):
+    """
+    Intended track type(s) used in this test are SD, ALL, STEREO_AUDIO, MULTICHANNEL_AUDIO
+    Expected to return HTTP 4xx error
+    """
+
+    xml_request = preset_2_widevine_request.decode('UTF-8')\
+        .replace("test_case_5_6", "test_case_negative_v_2_a_shared")\
+        .replace("intendedTrackType=\"HD\"", "intendedTrackType=\"ALL\"")
+
+    response = utils.speke_v2_request(spekev2_url, xml_request.encode('UTF-8'))
+
+    assert response.status_code != 200 and (400 <= response.status_code < 600), \
+        f"If intendedTrackType with ALL is requested, there cannot be other ContentKeyUsageRule elements with " \
+        f"different intendedTrackType values "
+
+
+def test_shared_video_preset_and_audio_preset_2_request_expect_4xx(spekev2_url, preset_2_widevine_request):
+    """
+    Intended track type(s) used in this test are SD, HD, ALL, MULTICHANNEL_AUDIO
+    :returns: HTTP 4xx error
+    """
+
+    xml_request = preset_2_widevine_request.decode('UTF-8')\
+        .replace("test_case_5_6", "test_case_negative_v_shared_a_2") \
+        .replace("intendedTrackType=\"STEREO_AUDIO\"", "intendedTrackType=\"ALL\"")
+    response = utils.speke_v2_request(spekev2_url, xml_request.encode('UTF-8'))
+
+    assert response.status_code != 200 and (400 <= response.status_code < 600), \
+        f"If intendedTrackType with ALL is requested, there cannot be other ContentKeyUsageRule elements with " \
+        f"different intendedTrackType values "


### PR DESCRIPTION
*Description of changes:*
Add tests and artifacts for Speke v2 SHARED and UNENCRYPTED presets 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
