### PR TITLE
Add <cpix:PSSH/ > as a required element for Fairplay

### DIFF
--- a/spekev2_verification_testsuite/helpers/speke_element_assertions.py
+++ b/spekev2_verification_testsuite/helpers/speke_element_assertions.py
@@ -207,8 +207,8 @@ def validate_drm_system_element_playready(drm_system_element):
 def validate_drm_system_element_fairplay(drm_system_element):
     pssh_data = drm_system_element.findall(
         './{urn:dashif:org:cpix}PSSH')
-    assert not pssh_data, \
-        "PSSH is not expected in this response"
+    assert pssh_data, \
+        "PSSH is expected in this response"
 
     content_protection_data = drm_system_element.findall(
         './{urn:dashif:org:cpix}ContentProtectionData')

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_1_p_v_1_a_1/3_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_1_p_v_1_a_1/3_fairplay.xml
@@ -10,12 +10,14 @@
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
         <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_1_p_v_1_a_1/5_widevine_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_1_p_v_1_a_1/5_widevine_fairplay.xml
@@ -26,12 +26,14 @@
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_1_p_v_1_a_1/6_playready_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_1_p_v_1_a_1/6_playready_fairplay.xml
@@ -26,12 +26,14 @@
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_1_p_v_1_a_1/7_widevine_playready_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_1_p_v_1_a_1/7_widevine_playready_fairplay.xml
@@ -26,12 +26,14 @@
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/3_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/3_fairplay.xml
@@ -19,30 +19,35 @@
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
         <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/5_widevine_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/5_widevine_fairplay.xml
@@ -59,30 +59,35 @@
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/6_playready_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/6_playready_fairplay.xml
@@ -59,30 +59,35 @@
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/7_widevine_playready_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/7_widevine_playready_fairplay.xml
@@ -99,30 +99,35 @@
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/3_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/3_fairplay.xml
@@ -28,48 +28,56 @@
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
         <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/5_widevine_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/5_widevine_fairplay.xml
@@ -93,48 +93,56 @@
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/6_playready_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/6_playready_fairplay.xml
@@ -93,48 +93,56 @@
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/7_widevine_playready_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/7_widevine_playready_fairplay.xml
@@ -157,48 +157,56 @@
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/3_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/3_fairplay.xml
@@ -23,36 +23,42 @@
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
         <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/5_widevine_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/5_widevine_fairplay.xml
@@ -71,36 +71,42 @@
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/6_playready_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/6_playready_fairplay.xml
@@ -71,36 +71,42 @@
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/7_widevine_playready_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/7_widevine_playready_fairplay.xml
@@ -119,36 +119,42 @@
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/3_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/3_fairplay.xml
@@ -16,24 +16,28 @@
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
         <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/5_widevine_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/5_widevine_fairplay.xml
@@ -40,7 +40,7 @@
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
-             <cpix:PSSH />
+            <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
@@ -48,24 +48,28 @@
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/6_playready_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/6_playready_fairplay.xml
@@ -48,24 +48,28 @@
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/7_widevine_playready_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/7_widevine_playready_fairplay.xml
@@ -80,24 +80,28 @@
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
         <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+            <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">


### PR DESCRIPTION
*Description of changes:*
- MediaPackage includes <cpix:PSSH/ > in the request sent, and according to the Speke v2 spec, if its present in the request it must be in the response. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
