### PR TITLE
verification test suite: new key IDs for every test case

### DIFF
--- a/spekev2_verification_testsuite/spekev2_requests/general/5_speke_v1_style_implementation.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/general/5_speke_v1_style_implementation.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <cpix:CPIX contentId="cenc_test_001" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:enc="http://www.w3.org/2001/04/xmlenc#">
     <cpix:ContentKeyList>
-        <cpix:ContentKey kid="0f083e4e-b831-4a3d-917e-ce78076e54aa" commonEncryptionScheme="cenc"></cpix:ContentKey>
+        <cpix:ContentKey kid="90d343b4-361f-444f-893e-9e0ae74e958f" commonEncryptionScheme="cenc"></cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
-        <cpix:DRMSystem kid="0f083e4e-b831-4a3d-917e-ce78076e54aa" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="90d343b4-361f-444f-893e-9e0ae74e958f" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -14,7 +14,7 @@
         </cpix:DRMSystem>
     </cpix:DRMSystemList>
     <cpix:ContentKeyUsageRuleList>
-        <cpix:ContentKeyUsageRule kid="0f083e4e-b831-4a3d-917e-ce78076e54aa" intendedTrackType="ALL">
+        <cpix:ContentKeyUsageRule kid="90d343b4-361f-444f-893e-9e0ae74e958f" intendedTrackType="ALL">
             <cpix:VideoFilter />
             <cpix:AudioFilter />
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/1_widevine.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/1_widevine.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <cpix:CPIX contentId="test_case_2" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
-        <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
+        <cpix:ContentKey kid="93f5fb58-1df7-4752-acb2-6cf1e75b4910"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+        <cpix:ContentKey kid="e1f85ce6-5c99-442c-8cdf-5063550ca95b"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce"
+        <cpix:ContentKey kid="03341606-452b-46dd-8934-7e0720ba4f21"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
+        <cpix:ContentKey kid="ec0f62c0-4970-45df-8e8f-a01aeba219fe"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="80969196-fe0d-4c1b-aec3-522bebcbd61c"
+        <cpix:ContentKey kid="998e9209-ca6c-4c9e-8a60-bfbb135f5109"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="93f5fb58-1df7-4752-acb2-6cf1e75b4910" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -26,7 +26,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="e1f85ce6-5c99-442c-8cdf-5063550ca95b" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -34,7 +34,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="03341606-452b-46dd-8934-7e0720ba4f21" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -42,7 +42,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="ec0f62c0-4970-45df-8e8f-a01aeba219fe" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -50,7 +50,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="998e9209-ca6c-4c9e-8a60-bfbb135f5109" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -63,23 +63,23 @@
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
     </cpix:ContentKeyPeriodList>
     <cpix:ContentKeyUsageRuleList>
-        <cpix:ContentKeyUsageRule kid="873f3740-2508-4a2d-94bc-9b0f86649251" intendedTrackType="SD">
+        <cpix:ContentKeyUsageRule kid="93f5fb58-1df7-4752-acb2-6cf1e75b4910" intendedTrackType="SD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="589824" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD">
+        <cpix:ContentKeyUsageRule kid="e1f85ce6-5c99-442c-8cdf-5063550ca95b" intendedTrackType="HD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="589825" maxPixels="2073600" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" intendedTrackType="UHD">
+        <cpix:ContentKeyUsageRule kid="03341606-452b-46dd-8934-7e0720ba4f21" intendedTrackType="UHD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="2073601" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="STEREO_AUDIO">
+        <cpix:ContentKeyUsageRule kid="ec0f62c0-4970-45df-8e8f-a01aeba219fe" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO">
+        <cpix:ContentKeyUsageRule kid="998e9209-ca6c-4c9e-8a60-bfbb135f5109" intendedTrackType="MULTICHANNEL_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3" />
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/2_playready.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/2_playready.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <cpix:CPIX contentId="test_case_2" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
-        <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
+        <cpix:ContentKey kid="93f5fb58-1df7-4752-acb2-6cf1e75b4910"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+        <cpix:ContentKey kid="e1f85ce6-5c99-442c-8cdf-5063550ca95b"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce"
+        <cpix:ContentKey kid="03341606-452b-46dd-8934-7e0720ba4f21"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
+        <cpix:ContentKey kid="ec0f62c0-4970-45df-8e8f-a01aeba219fe"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="80969196-fe0d-4c1b-aec3-522bebcbd61c"
+        <cpix:ContentKey kid="998e9209-ca6c-4c9e-8a60-bfbb135f5109"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="93f5fb58-1df7-4752-acb2-6cf1e75b4910" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -26,7 +26,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="e1f85ce6-5c99-442c-8cdf-5063550ca95b" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -34,7 +34,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="03341606-452b-46dd-8934-7e0720ba4f21" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -42,7 +42,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="ec0f62c0-4970-45df-8e8f-a01aeba219fe" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -50,7 +50,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="998e9209-ca6c-4c9e-8a60-bfbb135f5109" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -63,23 +63,23 @@
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
     </cpix:ContentKeyPeriodList>
     <cpix:ContentKeyUsageRuleList>
-        <cpix:ContentKeyUsageRule kid="873f3740-2508-4a2d-94bc-9b0f86649251" intendedTrackType="SD">
+        <cpix:ContentKeyUsageRule kid="93f5fb58-1df7-4752-acb2-6cf1e75b4910" intendedTrackType="SD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="589824" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD">
+        <cpix:ContentKeyUsageRule kid="e1f85ce6-5c99-442c-8cdf-5063550ca95b" intendedTrackType="HD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="589825" maxPixels="2073600" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" intendedTrackType="UHD">
+        <cpix:ContentKeyUsageRule kid="03341606-452b-46dd-8934-7e0720ba4f21" intendedTrackType="UHD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="2073601" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="STEREO_AUDIO">
+        <cpix:ContentKeyUsageRule kid="ec0f62c0-4970-45df-8e8f-a01aeba219fe" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO">
+        <cpix:ContentKeyUsageRule kid="998e9209-ca6c-4c9e-8a60-bfbb135f5109" intendedTrackType="MULTICHANNEL_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3" />
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/3_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/3_fairplay.xml
@@ -1,52 +1,52 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <cpix:CPIX contentId="test_case_2" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
-        <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
+        <cpix:ContentKey kid="93f5fb58-1df7-4752-acb2-6cf1e75b4910"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+        <cpix:ContentKey kid="e1f85ce6-5c99-442c-8cdf-5063550ca95b"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce"
+        <cpix:ContentKey kid="03341606-452b-46dd-8934-7e0720ba4f21"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
+        <cpix:ContentKey kid="ec0f62c0-4970-45df-8e8f-a01aeba219fe"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="80969196-fe0d-4c1b-aec3-522bebcbd61c"
+        <cpix:ContentKey kid="998e9209-ca6c-4c9e-8a60-bfbb135f5109"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="93f5fb58-1df7-4752-acb2-6cf1e75b4910" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="e1f85ce6-5c99-442c-8cdf-5063550ca95b" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="03341606-452b-46dd-8934-7e0720ba4f21" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="ec0f62c0-4970-45df-8e8f-a01aeba219fe" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="998e9209-ca6c-4c9e-8a60-bfbb135f5109" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
@@ -58,23 +58,23 @@
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
     </cpix:ContentKeyPeriodList>
     <cpix:ContentKeyUsageRuleList>
-        <cpix:ContentKeyUsageRule kid="873f3740-2508-4a2d-94bc-9b0f86649251" intendedTrackType="SD">
+        <cpix:ContentKeyUsageRule kid="93f5fb58-1df7-4752-acb2-6cf1e75b4910" intendedTrackType="SD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="589824" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD">
+        <cpix:ContentKeyUsageRule kid="e1f85ce6-5c99-442c-8cdf-5063550ca95b" intendedTrackType="HD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="589825" maxPixels="2073600" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" intendedTrackType="UHD">
+        <cpix:ContentKeyUsageRule kid="03341606-452b-46dd-8934-7e0720ba4f21" intendedTrackType="UHD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="2073601" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="STEREO_AUDIO">
+        <cpix:ContentKeyUsageRule kid="ec0f62c0-4970-45df-8e8f-a01aeba219fe" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO">
+        <cpix:ContentKeyUsageRule kid="998e9209-ca6c-4c9e-8a60-bfbb135f5109" intendedTrackType="MULTICHANNEL_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3" />
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/4_widevine_playready.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/4_widevine_playready.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <cpix:CPIX contentId="test_case_2" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
-        <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
+        <cpix:ContentKey kid="93f5fb58-1df7-4752-acb2-6cf1e75b4910"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+        <cpix:ContentKey kid="e1f85ce6-5c99-442c-8cdf-5063550ca95b"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce"
+        <cpix:ContentKey kid="03341606-452b-46dd-8934-7e0720ba4f21"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
+        <cpix:ContentKey kid="ec0f62c0-4970-45df-8e8f-a01aeba219fe"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="80969196-fe0d-4c1b-aec3-522bebcbd61c"
+        <cpix:ContentKey kid="998e9209-ca6c-4c9e-8a60-bfbb135f5109"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="93f5fb58-1df7-4752-acb2-6cf1e75b4910" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -26,7 +26,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="e1f85ce6-5c99-442c-8cdf-5063550ca95b" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -34,7 +34,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="03341606-452b-46dd-8934-7e0720ba4f21" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -42,7 +42,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="ec0f62c0-4970-45df-8e8f-a01aeba219fe" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -50,7 +50,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="998e9209-ca6c-4c9e-8a60-bfbb135f5109" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -58,7 +58,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="93f5fb58-1df7-4752-acb2-6cf1e75b4910" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -66,7 +66,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="e1f85ce6-5c99-442c-8cdf-5063550ca95b" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -74,7 +74,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="03341606-452b-46dd-8934-7e0720ba4f21" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -82,7 +82,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="ec0f62c0-4970-45df-8e8f-a01aeba219fe" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -90,7 +90,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="998e9209-ca6c-4c9e-8a60-bfbb135f5109" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -103,23 +103,23 @@
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
     </cpix:ContentKeyPeriodList>
     <cpix:ContentKeyUsageRuleList>
-        <cpix:ContentKeyUsageRule kid="873f3740-2508-4a2d-94bc-9b0f86649251" intendedTrackType="SD">
+        <cpix:ContentKeyUsageRule kid="93f5fb58-1df7-4752-acb2-6cf1e75b4910" intendedTrackType="SD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="589824" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD">
+        <cpix:ContentKeyUsageRule kid="e1f85ce6-5c99-442c-8cdf-5063550ca95b" intendedTrackType="HD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="589825" maxPixels="2073600" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" intendedTrackType="UHD">
+        <cpix:ContentKeyUsageRule kid="03341606-452b-46dd-8934-7e0720ba4f21" intendedTrackType="UHD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="2073601" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="STEREO_AUDIO">
+        <cpix:ContentKeyUsageRule kid="ec0f62c0-4970-45df-8e8f-a01aeba219fe" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO">
+        <cpix:ContentKeyUsageRule kid="998e9209-ca6c-4c9e-8a60-bfbb135f5109" intendedTrackType="MULTICHANNEL_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3" />
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/5_widevine_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/5_widevine_fairplay.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <cpix:CPIX contentId="test_case_2" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
-        <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
+        <cpix:ContentKey kid="93f5fb58-1df7-4752-acb2-6cf1e75b4910"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+        <cpix:ContentKey kid="e1f85ce6-5c99-442c-8cdf-5063550ca95b"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce"
+        <cpix:ContentKey kid="03341606-452b-46dd-8934-7e0720ba4f21"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
+        <cpix:ContentKey kid="ec0f62c0-4970-45df-8e8f-a01aeba219fe"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="80969196-fe0d-4c1b-aec3-522bebcbd61c"
+        <cpix:ContentKey kid="998e9209-ca6c-4c9e-8a60-bfbb135f5109"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="93f5fb58-1df7-4752-acb2-6cf1e75b4910" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -26,7 +26,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="e1f85ce6-5c99-442c-8cdf-5063550ca95b" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -34,7 +34,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="03341606-452b-46dd-8934-7e0720ba4f21" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -42,7 +42,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="ec0f62c0-4970-45df-8e8f-a01aeba219fe" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -50,7 +50,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="998e9209-ca6c-4c9e-8a60-bfbb135f5109" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -58,35 +58,35 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="93f5fb58-1df7-4752-acb2-6cf1e75b4910" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="e1f85ce6-5c99-442c-8cdf-5063550ca95b" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="03341606-452b-46dd-8934-7e0720ba4f21" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="ec0f62c0-4970-45df-8e8f-a01aeba219fe" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
              <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="998e9209-ca6c-4c9e-8a60-bfbb135f5109" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
@@ -98,23 +98,23 @@
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
     </cpix:ContentKeyPeriodList>
     <cpix:ContentKeyUsageRuleList>
-        <cpix:ContentKeyUsageRule kid="873f3740-2508-4a2d-94bc-9b0f86649251" intendedTrackType="SD">
+        <cpix:ContentKeyUsageRule kid="93f5fb58-1df7-4752-acb2-6cf1e75b4910" intendedTrackType="SD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="589824" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD">
+        <cpix:ContentKeyUsageRule kid="e1f85ce6-5c99-442c-8cdf-5063550ca95b" intendedTrackType="HD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="589825" maxPixels="2073600" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" intendedTrackType="UHD">
+        <cpix:ContentKeyUsageRule kid="03341606-452b-46dd-8934-7e0720ba4f21" intendedTrackType="UHD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="2073601" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="STEREO_AUDIO">
+        <cpix:ContentKeyUsageRule kid="ec0f62c0-4970-45df-8e8f-a01aeba219fe" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO">
+        <cpix:ContentKeyUsageRule kid="998e9209-ca6c-4c9e-8a60-bfbb135f5109" intendedTrackType="MULTICHANNEL_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3" />
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/6_playready_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/6_playready_fairplay.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <cpix:CPIX contentId="test_case_2" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
-        <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
+        <cpix:ContentKey kid="93f5fb58-1df7-4752-acb2-6cf1e75b4910"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+        <cpix:ContentKey kid="e1f85ce6-5c99-442c-8cdf-5063550ca95b"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce"
+        <cpix:ContentKey kid="03341606-452b-46dd-8934-7e0720ba4f21"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
+        <cpix:ContentKey kid="ec0f62c0-4970-45df-8e8f-a01aeba219fe"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="80969196-fe0d-4c1b-aec3-522bebcbd61c"
+        <cpix:ContentKey kid="998e9209-ca6c-4c9e-8a60-bfbb135f5109"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="93f5fb58-1df7-4752-acb2-6cf1e75b4910" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -26,7 +26,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="e1f85ce6-5c99-442c-8cdf-5063550ca95b" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -34,7 +34,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="03341606-452b-46dd-8934-7e0720ba4f21" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -42,7 +42,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="ec0f62c0-4970-45df-8e8f-a01aeba219fe" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -50,7 +50,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="998e9209-ca6c-4c9e-8a60-bfbb135f5109" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -58,35 +58,35 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="93f5fb58-1df7-4752-acb2-6cf1e75b4910" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="e1f85ce6-5c99-442c-8cdf-5063550ca95b" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="03341606-452b-46dd-8934-7e0720ba4f21" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="ec0f62c0-4970-45df-8e8f-a01aeba219fe" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="998e9209-ca6c-4c9e-8a60-bfbb135f5109" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
@@ -98,23 +98,23 @@
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
     </cpix:ContentKeyPeriodList>
     <cpix:ContentKeyUsageRuleList>
-        <cpix:ContentKeyUsageRule kid="873f3740-2508-4a2d-94bc-9b0f86649251" intendedTrackType="SD">
+        <cpix:ContentKeyUsageRule kid="93f5fb58-1df7-4752-acb2-6cf1e75b4910" intendedTrackType="SD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="589824" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD">
+        <cpix:ContentKeyUsageRule kid="e1f85ce6-5c99-442c-8cdf-5063550ca95b" intendedTrackType="HD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="589825" maxPixels="2073600" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" intendedTrackType="UHD">
+        <cpix:ContentKeyUsageRule kid="03341606-452b-46dd-8934-7e0720ba4f21" intendedTrackType="UHD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="2073601" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="STEREO_AUDIO">
+        <cpix:ContentKeyUsageRule kid="ec0f62c0-4970-45df-8e8f-a01aeba219fe" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO">
+        <cpix:ContentKeyUsageRule kid="998e9209-ca6c-4c9e-8a60-bfbb135f5109" intendedTrackType="MULTICHANNEL_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3" />
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/7_widevine_playready_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_2_p_v_3_a_2/7_widevine_playready_fairplay.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <cpix:CPIX contentId="test_case_2" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
-        <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
+        <cpix:ContentKey kid="93f5fb58-1df7-4752-acb2-6cf1e75b4910"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+        <cpix:ContentKey kid="e1f85ce6-5c99-442c-8cdf-5063550ca95b"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce"
+        <cpix:ContentKey kid="03341606-452b-46dd-8934-7e0720ba4f21"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
+        <cpix:ContentKey kid="ec0f62c0-4970-45df-8e8f-a01aeba219fe"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="80969196-fe0d-4c1b-aec3-522bebcbd61c"
+        <cpix:ContentKey kid="998e9209-ca6c-4c9e-8a60-bfbb135f5109"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="93f5fb58-1df7-4752-acb2-6cf1e75b4910" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -26,7 +26,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="e1f85ce6-5c99-442c-8cdf-5063550ca95b" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -34,7 +34,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="03341606-452b-46dd-8934-7e0720ba4f21" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -42,7 +42,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="ec0f62c0-4970-45df-8e8f-a01aeba219fe" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -50,7 +50,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="998e9209-ca6c-4c9e-8a60-bfbb135f5109" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -58,7 +58,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="93f5fb58-1df7-4752-acb2-6cf1e75b4910" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -66,7 +66,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="e1f85ce6-5c99-442c-8cdf-5063550ca95b" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -74,7 +74,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="03341606-452b-46dd-8934-7e0720ba4f21" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -82,7 +82,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="ec0f62c0-4970-45df-8e8f-a01aeba219fe" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -90,7 +90,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="998e9209-ca6c-4c9e-8a60-bfbb135f5109" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -98,35 +98,35 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="93f5fb58-1df7-4752-acb2-6cf1e75b4910" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="e1f85ce6-5c99-442c-8cdf-5063550ca95b" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="03341606-452b-46dd-8934-7e0720ba4f21" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="ec0f62c0-4970-45df-8e8f-a01aeba219fe" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="998e9209-ca6c-4c9e-8a60-bfbb135f5109" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
@@ -138,23 +138,23 @@
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
     </cpix:ContentKeyPeriodList>
     <cpix:ContentKeyUsageRuleList>
-        <cpix:ContentKeyUsageRule kid="873f3740-2508-4a2d-94bc-9b0f86649251" intendedTrackType="SD">
+        <cpix:ContentKeyUsageRule kid="93f5fb58-1df7-4752-acb2-6cf1e75b4910" intendedTrackType="SD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="589824" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD">
+        <cpix:ContentKeyUsageRule kid="e1f85ce6-5c99-442c-8cdf-5063550ca95b" intendedTrackType="HD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="589825" maxPixels="2073600" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" intendedTrackType="UHD">
+        <cpix:ContentKeyUsageRule kid="03341606-452b-46dd-8934-7e0720ba4f21" intendedTrackType="UHD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="2073601" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="STEREO_AUDIO">
+        <cpix:ContentKeyUsageRule kid="ec0f62c0-4970-45df-8e8f-a01aeba219fe" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO">
+        <cpix:ContentKeyUsageRule kid="998e9209-ca6c-4c9e-8a60-bfbb135f5109" intendedTrackType="MULTICHANNEL_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3" />
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/1_widevine.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/1_widevine.xml
@@ -2,33 +2,33 @@
 <cpix:CPIX contentId="test_case_3" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
            xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
-        <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
+        <cpix:ContentKey kid="5c360e3b-7a5d-477d-b0f1-2991bf757d77"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+        <cpix:ContentKey kid="60855919-7714-4548-9223-145978a3ec4a"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce"
+        <cpix:ContentKey kid="1dc47aac-426f-41d9-8d30-26d6c4881445"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01"
+        <cpix:ContentKey kid="c66efe8f-7acb-4740-8aff-6cb4326bf24b"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d"
+        <cpix:ContentKey kid="ce88d2d5-158b-47df-96b9-b0e2e8512862"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
+        <cpix:ContentKey kid="cd5ad12e-6d61-459a-9a09-a981f7d3ab93"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="80969196-fe0d-4c1b-aec3-522bebcbd61c"
+        <cpix:ContentKey kid="79a41e91-5345-45cc-bd95-6b9c94ba0dcd"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0"
+        <cpix:ContentKey kid="2dee023c-3898-4f79-9ee8-316714b5a3bd"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="5c360e3b-7a5d-477d-b0f1-2991bf757d77" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -36,7 +36,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="60855919-7714-4548-9223-145978a3ec4a" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -44,7 +44,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="1dc47aac-426f-41d9-8d30-26d6c4881445" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -52,7 +52,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="c66efe8f-7acb-4740-8aff-6cb4326bf24b" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -60,7 +60,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="ce88d2d5-158b-47df-96b9-b0e2e8512862" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -68,7 +68,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="cd5ad12e-6d61-459a-9a09-a981f7d3ab93" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -76,7 +76,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="79a41e91-5345-45cc-bd95-6b9c94ba0dcd" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -84,7 +84,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="2dee023c-3898-4f79-9ee8-316714b5a3bd" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -97,35 +97,35 @@
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
     </cpix:ContentKeyPeriodList>
     <cpix:ContentKeyUsageRuleList>
-        <cpix:ContentKeyUsageRule kid="873f3740-2508-4a2d-94bc-9b0f86649251" intendedTrackType="SD">
+        <cpix:ContentKeyUsageRule kid="5c360e3b-7a5d-477d-b0f1-2991bf757d77" intendedTrackType="SD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="589824"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD1">
+        <cpix:ContentKeyUsageRule kid="60855919-7714-4548-9223-145978a3ec4a" intendedTrackType="HD1">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="589825" maxPixels="921600"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" intendedTrackType="HD2">
+        <cpix:ContentKeyUsageRule kid="1dc47aac-426f-41d9-8d30-26d6c4881445" intendedTrackType="HD2">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="921601" maxPixels="2073600"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" intendedTrackType="UHD1">
+        <cpix:ContentKeyUsageRule kid="c66efe8f-7acb-4740-8aff-6cb4326bf24b" intendedTrackType="UHD1">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="2073601" maxPixels="8847360"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" intendedTrackType="UHD2">
+        <cpix:ContentKeyUsageRule kid="ce88d2d5-158b-47df-96b9-b0e2e8512862" intendedTrackType="UHD2">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="8847361"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="STEREO_AUDIO">
+        <cpix:ContentKeyUsageRule kid="cd5ad12e-6d61-459a-9a09-a981f7d3ab93" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO_3_6">
+        <cpix:ContentKeyUsageRule kid="79a41e91-5345-45cc-bd95-6b9c94ba0dcd" intendedTrackType="MULTICHANNEL_AUDIO_3_6">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3" maxChannels="6"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" intendedTrackType="MULTICHANNEL_AUDIO_7">
+        <cpix:ContentKeyUsageRule kid="2dee023c-3898-4f79-9ee8-316714b5a3bd" intendedTrackType="MULTICHANNEL_AUDIO_7">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="7"/>
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/2_playready.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/2_playready.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <cpix:CPIX contentId="test_case_3" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
-        <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
+        <cpix:ContentKey kid="5c360e3b-7a5d-477d-b0f1-2991bf757d77"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+        <cpix:ContentKey kid="60855919-7714-4548-9223-145978a3ec4a"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce"
+        <cpix:ContentKey kid="1dc47aac-426f-41d9-8d30-26d6c4881445"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01"
+        <cpix:ContentKey kid="c66efe8f-7acb-4740-8aff-6cb4326bf24b"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d"
+        <cpix:ContentKey kid="ce88d2d5-158b-47df-96b9-b0e2e8512862"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
+        <cpix:ContentKey kid="cd5ad12e-6d61-459a-9a09-a981f7d3ab93"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="80969196-fe0d-4c1b-aec3-522bebcbd61c"
+        <cpix:ContentKey kid="79a41e91-5345-45cc-bd95-6b9c94ba0dcd"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0"
+        <cpix:ContentKey kid="2dee023c-3898-4f79-9ee8-316714b5a3bd"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="5c360e3b-7a5d-477d-b0f1-2991bf757d77" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -35,7 +35,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="60855919-7714-4548-9223-145978a3ec4a" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -43,7 +43,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="1dc47aac-426f-41d9-8d30-26d6c4881445" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -51,7 +51,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="c66efe8f-7acb-4740-8aff-6cb4326bf24b" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -59,7 +59,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="ce88d2d5-158b-47df-96b9-b0e2e8512862" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -67,7 +67,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="cd5ad12e-6d61-459a-9a09-a981f7d3ab93" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -75,7 +75,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="79a41e91-5345-45cc-bd95-6b9c94ba0dcd" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -83,7 +83,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="2dee023c-3898-4f79-9ee8-316714b5a3bd" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -96,35 +96,35 @@
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
     </cpix:ContentKeyPeriodList>
     <cpix:ContentKeyUsageRuleList>
-        <cpix:ContentKeyUsageRule kid="873f3740-2508-4a2d-94bc-9b0f86649251" intendedTrackType="SD">
+        <cpix:ContentKeyUsageRule kid="5c360e3b-7a5d-477d-b0f1-2991bf757d77" intendedTrackType="SD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="589824" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD1">
+        <cpix:ContentKeyUsageRule kid="60855919-7714-4548-9223-145978a3ec4a" intendedTrackType="HD1">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="589825" maxPixels="921600" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" intendedTrackType="HD2">
+        <cpix:ContentKeyUsageRule kid="1dc47aac-426f-41d9-8d30-26d6c4881445" intendedTrackType="HD2">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="921601" maxPixels="2073600" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" intendedTrackType="UHD1">
+        <cpix:ContentKeyUsageRule kid="c66efe8f-7acb-4740-8aff-6cb4326bf24b" intendedTrackType="UHD1">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="2073601" maxPixels="8847360" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" intendedTrackType="UHD2">
+        <cpix:ContentKeyUsageRule kid="ce88d2d5-158b-47df-96b9-b0e2e8512862" intendedTrackType="UHD2">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="8847361" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="STEREO_AUDIO">
+        <cpix:ContentKeyUsageRule kid="cd5ad12e-6d61-459a-9a09-a981f7d3ab93" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO_3_6">
+        <cpix:ContentKeyUsageRule kid="79a41e91-5345-45cc-bd95-6b9c94ba0dcd" intendedTrackType="MULTICHANNEL_AUDIO_3_6">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3" maxChannels="6" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" intendedTrackType="MULTICHANNEL_AUDIO_7">
+        <cpix:ContentKeyUsageRule kid="2dee023c-3898-4f79-9ee8-316714b5a3bd" intendedTrackType="MULTICHANNEL_AUDIO_7">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="7" />
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/3_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/3_fairplay.xml
@@ -1,82 +1,82 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <cpix:CPIX contentId="test_case_3" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
-        <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
+        <cpix:ContentKey kid="5c360e3b-7a5d-477d-b0f1-2991bf757d77"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+        <cpix:ContentKey kid="60855919-7714-4548-9223-145978a3ec4a"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce"
+        <cpix:ContentKey kid="1dc47aac-426f-41d9-8d30-26d6c4881445"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01"
+        <cpix:ContentKey kid="c66efe8f-7acb-4740-8aff-6cb4326bf24b"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d"
+        <cpix:ContentKey kid="ce88d2d5-158b-47df-96b9-b0e2e8512862"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
+        <cpix:ContentKey kid="cd5ad12e-6d61-459a-9a09-a981f7d3ab93"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="80969196-fe0d-4c1b-aec3-522bebcbd61c"
+        <cpix:ContentKey kid="79a41e91-5345-45cc-bd95-6b9c94ba0dcd"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0"
+        <cpix:ContentKey kid="2dee023c-3898-4f79-9ee8-316714b5a3bd"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="5c360e3b-7a5d-477d-b0f1-2991bf757d77" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="60855919-7714-4548-9223-145978a3ec4a" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="1dc47aac-426f-41d9-8d30-26d6c4881445" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="c66efe8f-7acb-4740-8aff-6cb4326bf24b" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="ce88d2d5-158b-47df-96b9-b0e2e8512862" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="cd5ad12e-6d61-459a-9a09-a981f7d3ab93" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="79a41e91-5345-45cc-bd95-6b9c94ba0dcd" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="2dee023c-3898-4f79-9ee8-316714b5a3bd" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
@@ -88,35 +88,35 @@
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
     </cpix:ContentKeyPeriodList>
     <cpix:ContentKeyUsageRuleList>
-        <cpix:ContentKeyUsageRule kid="873f3740-2508-4a2d-94bc-9b0f86649251" intendedTrackType="SD">
+        <cpix:ContentKeyUsageRule kid="5c360e3b-7a5d-477d-b0f1-2991bf757d77" intendedTrackType="SD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="589824" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD1">
+        <cpix:ContentKeyUsageRule kid="60855919-7714-4548-9223-145978a3ec4a" intendedTrackType="HD1">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="589825" maxPixels="921600" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" intendedTrackType="HD2">
+        <cpix:ContentKeyUsageRule kid="1dc47aac-426f-41d9-8d30-26d6c4881445" intendedTrackType="HD2">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="921601" maxPixels="2073600" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" intendedTrackType="UHD1">
+        <cpix:ContentKeyUsageRule kid="c66efe8f-7acb-4740-8aff-6cb4326bf24b" intendedTrackType="UHD1">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="2073601" maxPixels="8847360" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" intendedTrackType="UHD2">
+        <cpix:ContentKeyUsageRule kid="ce88d2d5-158b-47df-96b9-b0e2e8512862" intendedTrackType="UHD2">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="8847361" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="STEREO_AUDIO">
+        <cpix:ContentKeyUsageRule kid="cd5ad12e-6d61-459a-9a09-a981f7d3ab93" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO_3_6">
+        <cpix:ContentKeyUsageRule kid="79a41e91-5345-45cc-bd95-6b9c94ba0dcd" intendedTrackType="MULTICHANNEL_AUDIO_3_6">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3" maxChannels="6" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" intendedTrackType="MULTICHANNEL_AUDIO_7">
+        <cpix:ContentKeyUsageRule kid="2dee023c-3898-4f79-9ee8-316714b5a3bd" intendedTrackType="MULTICHANNEL_AUDIO_7">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="7" />
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/4_widevine_playready.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/4_widevine_playready.xml
@@ -2,33 +2,33 @@
 <cpix:CPIX contentId="test_case_3" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
            xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
-        <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
+        <cpix:ContentKey kid="5c360e3b-7a5d-477d-b0f1-2991bf757d77"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+        <cpix:ContentKey kid="60855919-7714-4548-9223-145978a3ec4a"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce"
+        <cpix:ContentKey kid="1dc47aac-426f-41d9-8d30-26d6c4881445"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01"
+        <cpix:ContentKey kid="c66efe8f-7acb-4740-8aff-6cb4326bf24b"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d"
+        <cpix:ContentKey kid="ce88d2d5-158b-47df-96b9-b0e2e8512862"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
+        <cpix:ContentKey kid="cd5ad12e-6d61-459a-9a09-a981f7d3ab93"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="80969196-fe0d-4c1b-aec3-522bebcbd61c"
+        <cpix:ContentKey kid="79a41e91-5345-45cc-bd95-6b9c94ba0dcd"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0"
+        <cpix:ContentKey kid="2dee023c-3898-4f79-9ee8-316714b5a3bd"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="5c360e3b-7a5d-477d-b0f1-2991bf757d77" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -36,7 +36,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="60855919-7714-4548-9223-145978a3ec4a" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -44,7 +44,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="1dc47aac-426f-41d9-8d30-26d6c4881445" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -52,7 +52,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="c66efe8f-7acb-4740-8aff-6cb4326bf24b" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -60,7 +60,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="ce88d2d5-158b-47df-96b9-b0e2e8512862" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -68,7 +68,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="cd5ad12e-6d61-459a-9a09-a981f7d3ab93" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -76,7 +76,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="79a41e91-5345-45cc-bd95-6b9c94ba0dcd" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -84,7 +84,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="2dee023c-3898-4f79-9ee8-316714b5a3bd" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -92,7 +92,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="5c360e3b-7a5d-477d-b0f1-2991bf757d77" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -100,7 +100,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="60855919-7714-4548-9223-145978a3ec4a" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -108,7 +108,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="1dc47aac-426f-41d9-8d30-26d6c4881445" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -116,7 +116,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="c66efe8f-7acb-4740-8aff-6cb4326bf24b" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -124,7 +124,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="ce88d2d5-158b-47df-96b9-b0e2e8512862" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -132,7 +132,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="cd5ad12e-6d61-459a-9a09-a981f7d3ab93" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -140,7 +140,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="79a41e91-5345-45cc-bd95-6b9c94ba0dcd" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -148,7 +148,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="2dee023c-3898-4f79-9ee8-316714b5a3bd" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -161,35 +161,35 @@
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
     </cpix:ContentKeyPeriodList>
     <cpix:ContentKeyUsageRuleList>
-        <cpix:ContentKeyUsageRule kid="873f3740-2508-4a2d-94bc-9b0f86649251" intendedTrackType="SD">
+        <cpix:ContentKeyUsageRule kid="5c360e3b-7a5d-477d-b0f1-2991bf757d77" intendedTrackType="SD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="589824"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD1">
+        <cpix:ContentKeyUsageRule kid="60855919-7714-4548-9223-145978a3ec4a" intendedTrackType="HD1">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="589825" maxPixels="921600"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" intendedTrackType="HD2">
+        <cpix:ContentKeyUsageRule kid="1dc47aac-426f-41d9-8d30-26d6c4881445" intendedTrackType="HD2">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="921601" maxPixels="2073600"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" intendedTrackType="UHD1">
+        <cpix:ContentKeyUsageRule kid="c66efe8f-7acb-4740-8aff-6cb4326bf24b" intendedTrackType="UHD1">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="2073601" maxPixels="8847360"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" intendedTrackType="UHD2">
+        <cpix:ContentKeyUsageRule kid="ce88d2d5-158b-47df-96b9-b0e2e8512862" intendedTrackType="UHD2">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="8847361"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="STEREO_AUDIO">
+        <cpix:ContentKeyUsageRule kid="cd5ad12e-6d61-459a-9a09-a981f7d3ab93" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO_3_6">
+        <cpix:ContentKeyUsageRule kid="79a41e91-5345-45cc-bd95-6b9c94ba0dcd" intendedTrackType="MULTICHANNEL_AUDIO_3_6">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3" maxChannels="6"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" intendedTrackType="MULTICHANNEL_AUDIO_7">
+        <cpix:ContentKeyUsageRule kid="2dee023c-3898-4f79-9ee8-316714b5a3bd" intendedTrackType="MULTICHANNEL_AUDIO_7">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="7"/>
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/5_widevine_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/5_widevine_fairplay.xml
@@ -2,33 +2,33 @@
 <cpix:CPIX contentId="test_case_3" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
            xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
-        <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
+        <cpix:ContentKey kid="5c360e3b-7a5d-477d-b0f1-2991bf757d77"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+        <cpix:ContentKey kid="60855919-7714-4548-9223-145978a3ec4a"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce"
+        <cpix:ContentKey kid="1dc47aac-426f-41d9-8d30-26d6c4881445"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01"
+        <cpix:ContentKey kid="c66efe8f-7acb-4740-8aff-6cb4326bf24b"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d"
+        <cpix:ContentKey kid="ce88d2d5-158b-47df-96b9-b0e2e8512862"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
+        <cpix:ContentKey kid="cd5ad12e-6d61-459a-9a09-a981f7d3ab93"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="80969196-fe0d-4c1b-aec3-522bebcbd61c"
+        <cpix:ContentKey kid="79a41e91-5345-45cc-bd95-6b9c94ba0dcd"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0"
+        <cpix:ContentKey kid="2dee023c-3898-4f79-9ee8-316714b5a3bd"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="5c360e3b-7a5d-477d-b0f1-2991bf757d77" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -36,7 +36,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="60855919-7714-4548-9223-145978a3ec4a" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -44,7 +44,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="1dc47aac-426f-41d9-8d30-26d6c4881445" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -52,7 +52,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="c66efe8f-7acb-4740-8aff-6cb4326bf24b" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -60,7 +60,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="ce88d2d5-158b-47df-96b9-b0e2e8512862" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -68,7 +68,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="cd5ad12e-6d61-459a-9a09-a981f7d3ab93" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -76,7 +76,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="79a41e91-5345-45cc-bd95-6b9c94ba0dcd" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -84,7 +84,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="2dee023c-3898-4f79-9ee8-316714b5a3bd" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -92,56 +92,56 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="5c360e3b-7a5d-477d-b0f1-2991bf757d77" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="60855919-7714-4548-9223-145978a3ec4a" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="1dc47aac-426f-41d9-8d30-26d6c4881445" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="c66efe8f-7acb-4740-8aff-6cb4326bf24b" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="ce88d2d5-158b-47df-96b9-b0e2e8512862" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="cd5ad12e-6d61-459a-9a09-a981f7d3ab93" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="79a41e91-5345-45cc-bd95-6b9c94ba0dcd" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="2dee023c-3898-4f79-9ee8-316714b5a3bd" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
@@ -153,35 +153,35 @@
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
     </cpix:ContentKeyPeriodList>
     <cpix:ContentKeyUsageRuleList>
-        <cpix:ContentKeyUsageRule kid="873f3740-2508-4a2d-94bc-9b0f86649251" intendedTrackType="SD">
+        <cpix:ContentKeyUsageRule kid="5c360e3b-7a5d-477d-b0f1-2991bf757d77" intendedTrackType="SD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="589824"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD1">
+        <cpix:ContentKeyUsageRule kid="60855919-7714-4548-9223-145978a3ec4a" intendedTrackType="HD1">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="589825" maxPixels="921600"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" intendedTrackType="HD2">
+        <cpix:ContentKeyUsageRule kid="1dc47aac-426f-41d9-8d30-26d6c4881445" intendedTrackType="HD2">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="921601" maxPixels="2073600"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" intendedTrackType="UHD1">
+        <cpix:ContentKeyUsageRule kid="c66efe8f-7acb-4740-8aff-6cb4326bf24b" intendedTrackType="UHD1">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="2073601" maxPixels="8847360"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" intendedTrackType="UHD2">
+        <cpix:ContentKeyUsageRule kid="ce88d2d5-158b-47df-96b9-b0e2e8512862" intendedTrackType="UHD2">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="8847361"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="STEREO_AUDIO">
+        <cpix:ContentKeyUsageRule kid="cd5ad12e-6d61-459a-9a09-a981f7d3ab93" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO_3_6">
+        <cpix:ContentKeyUsageRule kid="79a41e91-5345-45cc-bd95-6b9c94ba0dcd" intendedTrackType="MULTICHANNEL_AUDIO_3_6">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3" maxChannels="6"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" intendedTrackType="MULTICHANNEL_AUDIO_7">
+        <cpix:ContentKeyUsageRule kid="2dee023c-3898-4f79-9ee8-316714b5a3bd" intendedTrackType="MULTICHANNEL_AUDIO_7">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="7"/>
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/6_playready_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/6_playready_fairplay.xml
@@ -2,33 +2,33 @@
 <cpix:CPIX contentId="test_case_3" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
            xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
-        <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
+        <cpix:ContentKey kid="5c360e3b-7a5d-477d-b0f1-2991bf757d77"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+        <cpix:ContentKey kid="60855919-7714-4548-9223-145978a3ec4a"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce"
+        <cpix:ContentKey kid="1dc47aac-426f-41d9-8d30-26d6c4881445"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01"
+        <cpix:ContentKey kid="c66efe8f-7acb-4740-8aff-6cb4326bf24b"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d"
+        <cpix:ContentKey kid="ce88d2d5-158b-47df-96b9-b0e2e8512862"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
+        <cpix:ContentKey kid="cd5ad12e-6d61-459a-9a09-a981f7d3ab93"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="80969196-fe0d-4c1b-aec3-522bebcbd61c"
+        <cpix:ContentKey kid="79a41e91-5345-45cc-bd95-6b9c94ba0dcd"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0"
+        <cpix:ContentKey kid="2dee023c-3898-4f79-9ee8-316714b5a3bd"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="5c360e3b-7a5d-477d-b0f1-2991bf757d77" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -36,7 +36,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="60855919-7714-4548-9223-145978a3ec4a" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -44,7 +44,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="1dc47aac-426f-41d9-8d30-26d6c4881445" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -52,7 +52,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="c66efe8f-7acb-4740-8aff-6cb4326bf24b" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -60,7 +60,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="ce88d2d5-158b-47df-96b9-b0e2e8512862" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -68,7 +68,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="cd5ad12e-6d61-459a-9a09-a981f7d3ab93" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -76,7 +76,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="79a41e91-5345-45cc-bd95-6b9c94ba0dcd" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -84,7 +84,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="2dee023c-3898-4f79-9ee8-316714b5a3bd" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -92,56 +92,56 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="5c360e3b-7a5d-477d-b0f1-2991bf757d77" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="60855919-7714-4548-9223-145978a3ec4a" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="1dc47aac-426f-41d9-8d30-26d6c4881445" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="c66efe8f-7acb-4740-8aff-6cb4326bf24b" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="ce88d2d5-158b-47df-96b9-b0e2e8512862" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="cd5ad12e-6d61-459a-9a09-a981f7d3ab93" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="79a41e91-5345-45cc-bd95-6b9c94ba0dcd" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="2dee023c-3898-4f79-9ee8-316714b5a3bd" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
@@ -153,35 +153,35 @@
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
     </cpix:ContentKeyPeriodList>
     <cpix:ContentKeyUsageRuleList>
-        <cpix:ContentKeyUsageRule kid="873f3740-2508-4a2d-94bc-9b0f86649251" intendedTrackType="SD">
+        <cpix:ContentKeyUsageRule kid="5c360e3b-7a5d-477d-b0f1-2991bf757d77" intendedTrackType="SD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="589824"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD1">
+        <cpix:ContentKeyUsageRule kid="60855919-7714-4548-9223-145978a3ec4a" intendedTrackType="HD1">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="589825" maxPixels="921600"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" intendedTrackType="HD2">
+        <cpix:ContentKeyUsageRule kid="1dc47aac-426f-41d9-8d30-26d6c4881445" intendedTrackType="HD2">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="921601" maxPixels="2073600"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" intendedTrackType="UHD1">
+        <cpix:ContentKeyUsageRule kid="c66efe8f-7acb-4740-8aff-6cb4326bf24b" intendedTrackType="UHD1">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="2073601" maxPixels="8847360"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" intendedTrackType="UHD2">
+        <cpix:ContentKeyUsageRule kid="ce88d2d5-158b-47df-96b9-b0e2e8512862" intendedTrackType="UHD2">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="8847361"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="STEREO_AUDIO">
+        <cpix:ContentKeyUsageRule kid="cd5ad12e-6d61-459a-9a09-a981f7d3ab93" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO_3_6">
+        <cpix:ContentKeyUsageRule kid="79a41e91-5345-45cc-bd95-6b9c94ba0dcd" intendedTrackType="MULTICHANNEL_AUDIO_3_6">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3" maxChannels="6"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" intendedTrackType="MULTICHANNEL_AUDIO_7">
+        <cpix:ContentKeyUsageRule kid="2dee023c-3898-4f79-9ee8-316714b5a3bd" intendedTrackType="MULTICHANNEL_AUDIO_7">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="7"/>
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/7_widevine_playready_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_3_p_v_5_a_3/7_widevine_playready_fairplay.xml
@@ -2,33 +2,33 @@
 <cpix:CPIX contentId="test_case_3" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
            xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
-        <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
+        <cpix:ContentKey kid="5c360e3b-7a5d-477d-b0f1-2991bf757d77"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+        <cpix:ContentKey kid="60855919-7714-4548-9223-145978a3ec4a"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce"
+        <cpix:ContentKey kid="1dc47aac-426f-41d9-8d30-26d6c4881445"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01"
+        <cpix:ContentKey kid="c66efe8f-7acb-4740-8aff-6cb4326bf24b"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d"
+        <cpix:ContentKey kid="ce88d2d5-158b-47df-96b9-b0e2e8512862"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
+        <cpix:ContentKey kid="cd5ad12e-6d61-459a-9a09-a981f7d3ab93"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="80969196-fe0d-4c1b-aec3-522bebcbd61c"
+        <cpix:ContentKey kid="79a41e91-5345-45cc-bd95-6b9c94ba0dcd"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0"
+        <cpix:ContentKey kid="2dee023c-3898-4f79-9ee8-316714b5a3bd"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="5c360e3b-7a5d-477d-b0f1-2991bf757d77" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -36,7 +36,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="60855919-7714-4548-9223-145978a3ec4a" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -44,7 +44,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="1dc47aac-426f-41d9-8d30-26d6c4881445" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -52,7 +52,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="c66efe8f-7acb-4740-8aff-6cb4326bf24b" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -60,7 +60,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="ce88d2d5-158b-47df-96b9-b0e2e8512862" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -68,7 +68,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="cd5ad12e-6d61-459a-9a09-a981f7d3ab93" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -76,7 +76,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="79a41e91-5345-45cc-bd95-6b9c94ba0dcd" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -84,7 +84,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="2dee023c-3898-4f79-9ee8-316714b5a3bd" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -92,7 +92,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="5c360e3b-7a5d-477d-b0f1-2991bf757d77" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -100,7 +100,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="60855919-7714-4548-9223-145978a3ec4a" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -108,7 +108,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="1dc47aac-426f-41d9-8d30-26d6c4881445" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -116,7 +116,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="c66efe8f-7acb-4740-8aff-6cb4326bf24b" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -124,7 +124,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="ce88d2d5-158b-47df-96b9-b0e2e8512862" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -132,7 +132,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="cd5ad12e-6d61-459a-9a09-a981f7d3ab93" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -140,7 +140,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="79a41e91-5345-45cc-bd95-6b9c94ba0dcd" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -148,7 +148,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="2dee023c-3898-4f79-9ee8-316714b5a3bd" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -156,56 +156,56 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="5c360e3b-7a5d-477d-b0f1-2991bf757d77" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="60855919-7714-4548-9223-145978a3ec4a" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="1dc47aac-426f-41d9-8d30-26d6c4881445" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="c66efe8f-7acb-4740-8aff-6cb4326bf24b" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="ce88d2d5-158b-47df-96b9-b0e2e8512862" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="cd5ad12e-6d61-459a-9a09-a981f7d3ab93" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="79a41e91-5345-45cc-bd95-6b9c94ba0dcd" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="2dee023c-3898-4f79-9ee8-316714b5a3bd" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
@@ -217,35 +217,35 @@
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
     </cpix:ContentKeyPeriodList>
     <cpix:ContentKeyUsageRuleList>
-        <cpix:ContentKeyUsageRule kid="873f3740-2508-4a2d-94bc-9b0f86649251" intendedTrackType="SD">
+        <cpix:ContentKeyUsageRule kid="5c360e3b-7a5d-477d-b0f1-2991bf757d77" intendedTrackType="SD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="589824"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD1">
+        <cpix:ContentKeyUsageRule kid="60855919-7714-4548-9223-145978a3ec4a" intendedTrackType="HD1">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="589825" maxPixels="921600"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" intendedTrackType="HD2">
+        <cpix:ContentKeyUsageRule kid="1dc47aac-426f-41d9-8d30-26d6c4881445" intendedTrackType="HD2">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="921601" maxPixels="2073600"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" intendedTrackType="UHD1">
+        <cpix:ContentKeyUsageRule kid="c66efe8f-7acb-4740-8aff-6cb4326bf24b" intendedTrackType="UHD1">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="2073601" maxPixels="8847360"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" intendedTrackType="UHD2">
+        <cpix:ContentKeyUsageRule kid="ce88d2d5-158b-47df-96b9-b0e2e8512862" intendedTrackType="UHD2">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="8847361"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="STEREO_AUDIO">
+        <cpix:ContentKeyUsageRule kid="cd5ad12e-6d61-459a-9a09-a981f7d3ab93" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO_3_6">
+        <cpix:ContentKeyUsageRule kid="79a41e91-5345-45cc-bd95-6b9c94ba0dcd" intendedTrackType="MULTICHANNEL_AUDIO_3_6">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3" maxChannels="6"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="da81cfc8-130a-43a8-ad35-6b432af5f6e0" intendedTrackType="MULTICHANNEL_AUDIO_7">
+        <cpix:ContentKeyUsageRule kid="2dee023c-3898-4f79-9ee8-316714b5a3bd" intendedTrackType="MULTICHANNEL_AUDIO_7">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="7"/>
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/1_widevine.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/1_widevine.xml
@@ -2,27 +2,27 @@
 <cpix:CPIX contentId="test_case_4" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
            xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
-        <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
+        <cpix:ContentKey kid="f036f2e3-ed46-4d63-872d-1415cdb07293"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+        <cpix:ContentKey kid="e5eedce7-8e9c-4257-99e7-d819d0eb2074"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce"
+        <cpix:ContentKey kid="3702bc31-2540-4d61-8c64-9e748902e87f"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01"
+        <cpix:ContentKey kid="39733e30-81d7-41b9-bad0-57c9ed654421"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d"
+        <cpix:ContentKey kid="bada33f9-12e5-40b9-95d8-bb8ce2bb4f48"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
+        <cpix:ContentKey kid="79629e3b-ad79-4740-a56c-d2b96cf52659"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="f036f2e3-ed46-4d63-872d-1415cdb07293" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -30,7 +30,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="e5eedce7-8e9c-4257-99e7-d819d0eb2074" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -38,7 +38,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="3702bc31-2540-4d61-8c64-9e748902e87f" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -46,7 +46,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="39733e30-81d7-41b9-bad0-57c9ed654421" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -54,7 +54,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="bada33f9-12e5-40b9-95d8-bb8ce2bb4f48" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -62,7 +62,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="79629e3b-ad79-4740-a56c-d2b96cf52659" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -75,27 +75,27 @@
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
     </cpix:ContentKeyPeriodList>
     <cpix:ContentKeyUsageRuleList>
-        <cpix:ContentKeyUsageRule kid="873f3740-2508-4a2d-94bc-9b0f86649251" intendedTrackType="SD+HD1">
+        <cpix:ContentKeyUsageRule kid="f036f2e3-ed46-4d63-872d-1415cdb07293" intendedTrackType="SD+HD1">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="921600"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD2">
+        <cpix:ContentKeyUsageRule kid="e5eedce7-8e9c-4257-99e7-d819d0eb2074" intendedTrackType="HD2">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="921601" maxPixels="2073600"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" intendedTrackType="UHD1">
+        <cpix:ContentKeyUsageRule kid="3702bc31-2540-4d61-8c64-9e748902e87f" intendedTrackType="UHD1">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="2073601" maxPixels="8847360"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" intendedTrackType="UHD2">
+        <cpix:ContentKeyUsageRule kid="39733e30-81d7-41b9-bad0-57c9ed654421" intendedTrackType="UHD2">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="8847361"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" intendedTrackType="STEREO_AUDIO">
+        <cpix:ContentKeyUsageRule kid="bada33f9-12e5-40b9-95d8-bb8ce2bb4f48" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="MULTICHANNEL_AUDIO">
+        <cpix:ContentKeyUsageRule kid="79629e3b-ad79-4740-a56c-d2b96cf52659" intendedTrackType="MULTICHANNEL_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3"/>
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/2_playready.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/2_playready.xml
@@ -2,27 +2,27 @@
 <cpix:CPIX contentId="test_case_4" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
            xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
-        <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
+        <cpix:ContentKey kid="f036f2e3-ed46-4d63-872d-1415cdb07293"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+        <cpix:ContentKey kid="e5eedce7-8e9c-4257-99e7-d819d0eb2074"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce"
+        <cpix:ContentKey kid="3702bc31-2540-4d61-8c64-9e748902e87f"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01"
+        <cpix:ContentKey kid="39733e30-81d7-41b9-bad0-57c9ed654421"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d"
+        <cpix:ContentKey kid="bada33f9-12e5-40b9-95d8-bb8ce2bb4f48"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
+        <cpix:ContentKey kid="79629e3b-ad79-4740-a56c-d2b96cf52659"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="f036f2e3-ed46-4d63-872d-1415cdb07293" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -30,7 +30,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="e5eedce7-8e9c-4257-99e7-d819d0eb2074" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -38,7 +38,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="3702bc31-2540-4d61-8c64-9e748902e87f" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -46,7 +46,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="39733e30-81d7-41b9-bad0-57c9ed654421" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -54,7 +54,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="bada33f9-12e5-40b9-95d8-bb8ce2bb4f48" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -62,7 +62,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="79629e3b-ad79-4740-a56c-d2b96cf52659" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -75,27 +75,27 @@
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
     </cpix:ContentKeyPeriodList>
     <cpix:ContentKeyUsageRuleList>
-        <cpix:ContentKeyUsageRule kid="873f3740-2508-4a2d-94bc-9b0f86649251" intendedTrackType="SD+HD1">
+        <cpix:ContentKeyUsageRule kid="f036f2e3-ed46-4d63-872d-1415cdb07293" intendedTrackType="SD+HD1">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="921600"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD2">
+        <cpix:ContentKeyUsageRule kid="e5eedce7-8e9c-4257-99e7-d819d0eb2074" intendedTrackType="HD2">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="921601" maxPixels="2073600"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" intendedTrackType="UHD1">
+        <cpix:ContentKeyUsageRule kid="3702bc31-2540-4d61-8c64-9e748902e87f" intendedTrackType="UHD1">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="2073601" maxPixels="8847360"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" intendedTrackType="UHD2">
+        <cpix:ContentKeyUsageRule kid="39733e30-81d7-41b9-bad0-57c9ed654421" intendedTrackType="UHD2">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="8847361"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" intendedTrackType="STEREO_AUDIO">
+        <cpix:ContentKeyUsageRule kid="bada33f9-12e5-40b9-95d8-bb8ce2bb4f48" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="MULTICHANNEL_AUDIO">
+        <cpix:ContentKeyUsageRule kid="79629e3b-ad79-4740-a56c-d2b96cf52659" intendedTrackType="MULTICHANNEL_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3"/>
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/3_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/3_fairplay.xml
@@ -2,62 +2,62 @@
 <cpix:CPIX contentId="test_case_4" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
            xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
-        <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
+        <cpix:ContentKey kid="f036f2e3-ed46-4d63-872d-1415cdb07293"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+        <cpix:ContentKey kid="e5eedce7-8e9c-4257-99e7-d819d0eb2074"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce"
+        <cpix:ContentKey kid="3702bc31-2540-4d61-8c64-9e748902e87f"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01"
+        <cpix:ContentKey kid="39733e30-81d7-41b9-bad0-57c9ed654421"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d"
+        <cpix:ContentKey kid="bada33f9-12e5-40b9-95d8-bb8ce2bb4f48"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
+        <cpix:ContentKey kid="79629e3b-ad79-4740-a56c-d2b96cf52659"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="f036f2e3-ed46-4d63-872d-1415cdb07293" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="e5eedce7-8e9c-4257-99e7-d819d0eb2074" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="3702bc31-2540-4d61-8c64-9e748902e87f" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="39733e30-81d7-41b9-bad0-57c9ed654421" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="bada33f9-12e5-40b9-95d8-bb8ce2bb4f48" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="79629e3b-ad79-4740-a56c-d2b96cf52659" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
@@ -69,27 +69,27 @@
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
     </cpix:ContentKeyPeriodList>
     <cpix:ContentKeyUsageRuleList>
-        <cpix:ContentKeyUsageRule kid="873f3740-2508-4a2d-94bc-9b0f86649251" intendedTrackType="SD+HD1">
+        <cpix:ContentKeyUsageRule kid="f036f2e3-ed46-4d63-872d-1415cdb07293" intendedTrackType="SD+HD1">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="921600"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD2">
+        <cpix:ContentKeyUsageRule kid="e5eedce7-8e9c-4257-99e7-d819d0eb2074" intendedTrackType="HD2">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="921601" maxPixels="2073600"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" intendedTrackType="UHD1">
+        <cpix:ContentKeyUsageRule kid="3702bc31-2540-4d61-8c64-9e748902e87f" intendedTrackType="UHD1">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="2073601" maxPixels="8847360"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" intendedTrackType="UHD2">
+        <cpix:ContentKeyUsageRule kid="39733e30-81d7-41b9-bad0-57c9ed654421" intendedTrackType="UHD2">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="8847361"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" intendedTrackType="STEREO_AUDIO">
+        <cpix:ContentKeyUsageRule kid="bada33f9-12e5-40b9-95d8-bb8ce2bb4f48" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="MULTICHANNEL_AUDIO">
+        <cpix:ContentKeyUsageRule kid="79629e3b-ad79-4740-a56c-d2b96cf52659" intendedTrackType="MULTICHANNEL_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3"/>
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/4_widevine_playready.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/4_widevine_playready.xml
@@ -2,27 +2,27 @@
 <cpix:CPIX contentId="test_case_4" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
            xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
-        <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
+        <cpix:ContentKey kid="f036f2e3-ed46-4d63-872d-1415cdb07293"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+        <cpix:ContentKey kid="e5eedce7-8e9c-4257-99e7-d819d0eb2074"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce"
+        <cpix:ContentKey kid="3702bc31-2540-4d61-8c64-9e748902e87f"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01"
+        <cpix:ContentKey kid="39733e30-81d7-41b9-bad0-57c9ed654421"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d"
+        <cpix:ContentKey kid="bada33f9-12e5-40b9-95d8-bb8ce2bb4f48"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
+        <cpix:ContentKey kid="79629e3b-ad79-4740-a56c-d2b96cf52659"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="f036f2e3-ed46-4d63-872d-1415cdb07293" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -30,7 +30,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="e5eedce7-8e9c-4257-99e7-d819d0eb2074" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -38,7 +38,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="3702bc31-2540-4d61-8c64-9e748902e87f" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -46,7 +46,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="39733e30-81d7-41b9-bad0-57c9ed654421" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -54,7 +54,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="bada33f9-12e5-40b9-95d8-bb8ce2bb4f48" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -62,7 +62,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="79629e3b-ad79-4740-a56c-d2b96cf52659" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -70,7 +70,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="f036f2e3-ed46-4d63-872d-1415cdb07293" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -78,7 +78,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="e5eedce7-8e9c-4257-99e7-d819d0eb2074" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -86,7 +86,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="3702bc31-2540-4d61-8c64-9e748902e87f" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -94,7 +94,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="39733e30-81d7-41b9-bad0-57c9ed654421" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -102,7 +102,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="bada33f9-12e5-40b9-95d8-bb8ce2bb4f48" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -110,7 +110,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="79629e3b-ad79-4740-a56c-d2b96cf52659" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -123,27 +123,27 @@
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
     </cpix:ContentKeyPeriodList>
     <cpix:ContentKeyUsageRuleList>
-        <cpix:ContentKeyUsageRule kid="873f3740-2508-4a2d-94bc-9b0f86649251" intendedTrackType="SD+HD1">
+        <cpix:ContentKeyUsageRule kid="f036f2e3-ed46-4d63-872d-1415cdb07293" intendedTrackType="SD+HD1">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="921600"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD2">
+        <cpix:ContentKeyUsageRule kid="e5eedce7-8e9c-4257-99e7-d819d0eb2074" intendedTrackType="HD2">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="921601" maxPixels="2073600"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" intendedTrackType="UHD1">
+        <cpix:ContentKeyUsageRule kid="3702bc31-2540-4d61-8c64-9e748902e87f" intendedTrackType="UHD1">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="2073601" maxPixels="8847360"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" intendedTrackType="UHD2">
+        <cpix:ContentKeyUsageRule kid="39733e30-81d7-41b9-bad0-57c9ed654421" intendedTrackType="UHD2">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="8847361"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" intendedTrackType="STEREO_AUDIO">
+        <cpix:ContentKeyUsageRule kid="bada33f9-12e5-40b9-95d8-bb8ce2bb4f48" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="MULTICHANNEL_AUDIO">
+        <cpix:ContentKeyUsageRule kid="79629e3b-ad79-4740-a56c-d2b96cf52659" intendedTrackType="MULTICHANNEL_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3"/>
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/5_widevine_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/5_widevine_fairplay.xml
@@ -2,27 +2,27 @@
 <cpix:CPIX contentId="test_case_4" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
            xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
-        <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
+        <cpix:ContentKey kid="f036f2e3-ed46-4d63-872d-1415cdb07293"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+        <cpix:ContentKey kid="e5eedce7-8e9c-4257-99e7-d819d0eb2074"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce"
+        <cpix:ContentKey kid="3702bc31-2540-4d61-8c64-9e748902e87f"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01"
+        <cpix:ContentKey kid="39733e30-81d7-41b9-bad0-57c9ed654421"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d"
+        <cpix:ContentKey kid="bada33f9-12e5-40b9-95d8-bb8ce2bb4f48"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
+        <cpix:ContentKey kid="79629e3b-ad79-4740-a56c-d2b96cf52659"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="f036f2e3-ed46-4d63-872d-1415cdb07293" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -30,7 +30,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="e5eedce7-8e9c-4257-99e7-d819d0eb2074" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -38,7 +38,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="3702bc31-2540-4d61-8c64-9e748902e87f" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -46,7 +46,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="39733e30-81d7-41b9-bad0-57c9ed654421" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -54,7 +54,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="bada33f9-12e5-40b9-95d8-bb8ce2bb4f48" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -62,7 +62,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="79629e3b-ad79-4740-a56c-d2b96cf52659" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -70,42 +70,42 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="f036f2e3-ed46-4d63-872d-1415cdb07293" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="e5eedce7-8e9c-4257-99e7-d819d0eb2074" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="3702bc31-2540-4d61-8c64-9e748902e87f" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="39733e30-81d7-41b9-bad0-57c9ed654421" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="bada33f9-12e5-40b9-95d8-bb8ce2bb4f48" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="79629e3b-ad79-4740-a56c-d2b96cf52659" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
@@ -117,27 +117,27 @@
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
     </cpix:ContentKeyPeriodList>
     <cpix:ContentKeyUsageRuleList>
-        <cpix:ContentKeyUsageRule kid="873f3740-2508-4a2d-94bc-9b0f86649251" intendedTrackType="SD+HD1">
+        <cpix:ContentKeyUsageRule kid="f036f2e3-ed46-4d63-872d-1415cdb07293" intendedTrackType="SD+HD1">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="921600"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD2">
+        <cpix:ContentKeyUsageRule kid="e5eedce7-8e9c-4257-99e7-d819d0eb2074" intendedTrackType="HD2">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="921601" maxPixels="2073600"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" intendedTrackType="UHD1">
+        <cpix:ContentKeyUsageRule kid="3702bc31-2540-4d61-8c64-9e748902e87f" intendedTrackType="UHD1">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="2073601" maxPixels="8847360"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" intendedTrackType="UHD2">
+        <cpix:ContentKeyUsageRule kid="39733e30-81d7-41b9-bad0-57c9ed654421" intendedTrackType="UHD2">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="8847361"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" intendedTrackType="STEREO_AUDIO">
+        <cpix:ContentKeyUsageRule kid="bada33f9-12e5-40b9-95d8-bb8ce2bb4f48" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="MULTICHANNEL_AUDIO">
+        <cpix:ContentKeyUsageRule kid="79629e3b-ad79-4740-a56c-d2b96cf52659" intendedTrackType="MULTICHANNEL_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3"/>
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/6_playready_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/6_playready_fairplay.xml
@@ -2,27 +2,27 @@
 <cpix:CPIX contentId="test_case_4" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
            xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
-        <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
+        <cpix:ContentKey kid="f036f2e3-ed46-4d63-872d-1415cdb07293"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+        <cpix:ContentKey kid="e5eedce7-8e9c-4257-99e7-d819d0eb2074"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce"
+        <cpix:ContentKey kid="3702bc31-2540-4d61-8c64-9e748902e87f"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01"
+        <cpix:ContentKey kid="39733e30-81d7-41b9-bad0-57c9ed654421"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d"
+        <cpix:ContentKey kid="bada33f9-12e5-40b9-95d8-bb8ce2bb4f48"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
+        <cpix:ContentKey kid="79629e3b-ad79-4740-a56c-d2b96cf52659"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
-         <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+         <cpix:DRMSystem kid="f036f2e3-ed46-4d63-872d-1415cdb07293" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -30,7 +30,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="e5eedce7-8e9c-4257-99e7-d819d0eb2074" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -38,7 +38,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="3702bc31-2540-4d61-8c64-9e748902e87f" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -46,7 +46,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="39733e30-81d7-41b9-bad0-57c9ed654421" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -54,7 +54,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="bada33f9-12e5-40b9-95d8-bb8ce2bb4f48" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -62,7 +62,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="79629e3b-ad79-4740-a56c-d2b96cf52659" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -70,42 +70,42 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="f036f2e3-ed46-4d63-872d-1415cdb07293" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="e5eedce7-8e9c-4257-99e7-d819d0eb2074" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="3702bc31-2540-4d61-8c64-9e748902e87f" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="39733e30-81d7-41b9-bad0-57c9ed654421" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="bada33f9-12e5-40b9-95d8-bb8ce2bb4f48" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="79629e3b-ad79-4740-a56c-d2b96cf52659" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
@@ -117,27 +117,27 @@
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
     </cpix:ContentKeyPeriodList>
     <cpix:ContentKeyUsageRuleList>
-        <cpix:ContentKeyUsageRule kid="873f3740-2508-4a2d-94bc-9b0f86649251" intendedTrackType="SD+HD1">
+        <cpix:ContentKeyUsageRule kid="f036f2e3-ed46-4d63-872d-1415cdb07293" intendedTrackType="SD+HD1">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="921600"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD2">
+        <cpix:ContentKeyUsageRule kid="e5eedce7-8e9c-4257-99e7-d819d0eb2074" intendedTrackType="HD2">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="921601" maxPixels="2073600"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" intendedTrackType="UHD1">
+        <cpix:ContentKeyUsageRule kid="3702bc31-2540-4d61-8c64-9e748902e87f" intendedTrackType="UHD1">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="2073601" maxPixels="8847360"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" intendedTrackType="UHD2">
+        <cpix:ContentKeyUsageRule kid="39733e30-81d7-41b9-bad0-57c9ed654421" intendedTrackType="UHD2">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="8847361"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" intendedTrackType="STEREO_AUDIO">
+        <cpix:ContentKeyUsageRule kid="bada33f9-12e5-40b9-95d8-bb8ce2bb4f48" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="MULTICHANNEL_AUDIO">
+        <cpix:ContentKeyUsageRule kid="79629e3b-ad79-4740-a56c-d2b96cf52659" intendedTrackType="MULTICHANNEL_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3"/>
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/7_widevine_playready_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_4_p_v_8_a_2/7_widevine_playready_fairplay.xml
@@ -2,27 +2,27 @@
 <cpix:CPIX contentId="test_case_4" version="2.3" xmlns:cpix="urn:dashif:org:cpix"
            xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
-        <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
+        <cpix:ContentKey kid="f036f2e3-ed46-4d63-872d-1415cdb07293"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+        <cpix:ContentKey kid="e5eedce7-8e9c-4257-99e7-d819d0eb2074"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce"
+        <cpix:ContentKey kid="3702bc31-2540-4d61-8c64-9e748902e87f"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01"
+        <cpix:ContentKey kid="39733e30-81d7-41b9-bad0-57c9ed654421"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d"
+        <cpix:ContentKey kid="bada33f9-12e5-40b9-95d8-bb8ce2bb4f48"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
+        <cpix:ContentKey kid="79629e3b-ad79-4740-a56c-d2b96cf52659"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="f036f2e3-ed46-4d63-872d-1415cdb07293" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -30,7 +30,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="e5eedce7-8e9c-4257-99e7-d819d0eb2074" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -38,7 +38,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="3702bc31-2540-4d61-8c64-9e748902e87f" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -46,7 +46,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="39733e30-81d7-41b9-bad0-57c9ed654421" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -54,7 +54,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="bada33f9-12e5-40b9-95d8-bb8ce2bb4f48" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -62,7 +62,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="79629e3b-ad79-4740-a56c-d2b96cf52659" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -70,7 +70,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-         <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+         <cpix:DRMSystem kid="f036f2e3-ed46-4d63-872d-1415cdb07293" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -78,7 +78,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="e5eedce7-8e9c-4257-99e7-d819d0eb2074" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -86,7 +86,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="3702bc31-2540-4d61-8c64-9e748902e87f" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -94,7 +94,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="39733e30-81d7-41b9-bad0-57c9ed654421" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -102,7 +102,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="bada33f9-12e5-40b9-95d8-bb8ce2bb4f48" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -110,7 +110,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="79629e3b-ad79-4740-a56c-d2b96cf52659" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH/>
             <cpix:ContentProtectionData/>
             <cpix:HLSSignalingData playlist="media">
@@ -118,42 +118,42 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="f036f2e3-ed46-4d63-872d-1415cdb07293" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="e5eedce7-8e9c-4257-99e7-d819d0eb2074" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="3702bc31-2540-4d61-8c64-9e748902e87f" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="39733e30-81d7-41b9-bad0-57c9ed654421" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="bada33f9-12e5-40b9-95d8-bb8ce2bb4f48" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="79629e3b-ad79-4740-a56c-d2b96cf52659" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
@@ -165,27 +165,27 @@
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
     </cpix:ContentKeyPeriodList>
     <cpix:ContentKeyUsageRuleList>
-        <cpix:ContentKeyUsageRule kid="873f3740-2508-4a2d-94bc-9b0f86649251" intendedTrackType="SD+HD1">
+        <cpix:ContentKeyUsageRule kid="f036f2e3-ed46-4d63-872d-1415cdb07293" intendedTrackType="SD+HD1">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="921600"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD2">
+        <cpix:ContentKeyUsageRule kid="e5eedce7-8e9c-4257-99e7-d819d0eb2074" intendedTrackType="HD2">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="921601" maxPixels="2073600"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="69f75726-85a7-4a65-9e6c-f10f7eaff7ce" intendedTrackType="UHD1">
+        <cpix:ContentKeyUsageRule kid="3702bc31-2540-4d61-8c64-9e748902e87f" intendedTrackType="UHD1">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="2073601" maxPixels="8847360"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="a3cb0426-1d90-4f87-9f58-95809f4e0e01" intendedTrackType="UHD2">
+        <cpix:ContentKeyUsageRule kid="39733e30-81d7-41b9-bad0-57c9ed654421" intendedTrackType="UHD2">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="8847361"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="4123faa7-4914-4fba-ba36-a7eb93de5e3d" intendedTrackType="STEREO_AUDIO">
+        <cpix:ContentKeyUsageRule kid="bada33f9-12e5-40b9-95d8-bb8ce2bb4f48" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2"/>
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="MULTICHANNEL_AUDIO">
+        <cpix:ContentKeyUsageRule kid="79629e3b-ad79-4740-a56c-d2b96cf52659" intendedTrackType="MULTICHANNEL_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3"/>
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/1_widevine.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/1_widevine.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <cpix:CPIX contentId="test_case_5_6" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
-        <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
+        <cpix:ContentKey kid="cff143cc-f7ba-4f45-b7dc-11e789c70c1c"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+        <cpix:ContentKey kid="acd5dbee-1b29-451c-9125-4dbb7fd3f4b2"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
+        <cpix:ContentKey kid="faa20e04-b929-4959-85f7-3c2788cce887"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="80969196-fe0d-4c1b-aec3-522bebcbd61c"
+        <cpix:ContentKey kid="3aa729cd-b693-4377-960d-bd0c3c217897"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="cff143cc-f7ba-4f45-b7dc-11e789c70c1c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -23,7 +23,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="acd5dbee-1b29-451c-9125-4dbb7fd3f4b2" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -31,7 +31,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="faa20e04-b929-4959-85f7-3c2788cce887" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -39,7 +39,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="3aa729cd-b693-4377-960d-bd0c3c217897" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -52,19 +52,19 @@
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
     </cpix:ContentKeyPeriodList>
     <cpix:ContentKeyUsageRuleList>
-        <cpix:ContentKeyUsageRule kid="873f3740-2508-4a2d-94bc-9b0f86649251" intendedTrackType="SD">
+        <cpix:ContentKeyUsageRule kid="cff143cc-f7ba-4f45-b7dc-11e789c70c1c" intendedTrackType="SD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="589824" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD">
+        <cpix:ContentKeyUsageRule kid="acd5dbee-1b29-451c-9125-4dbb7fd3f4b2" intendedTrackType="HD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="589825" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="STEREO_AUDIO">
+        <cpix:ContentKeyUsageRule kid="faa20e04-b929-4959-85f7-3c2788cce887" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO">
+        <cpix:ContentKeyUsageRule kid="3aa729cd-b693-4377-960d-bd0c3c217897" intendedTrackType="MULTICHANNEL_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3" />
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/2_playready.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/2_playready.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <cpix:CPIX contentId="test_case_5_6" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
-        <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
+        <cpix:ContentKey kid="cff143cc-f7ba-4f45-b7dc-11e789c70c1c"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+        <cpix:ContentKey kid="acd5dbee-1b29-451c-9125-4dbb7fd3f4b2"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
+        <cpix:ContentKey kid="faa20e04-b929-4959-85f7-3c2788cce887"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="80969196-fe0d-4c1b-aec3-522bebcbd61c"
+        <cpix:ContentKey kid="3aa729cd-b693-4377-960d-bd0c3c217897"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="cff143cc-f7ba-4f45-b7dc-11e789c70c1c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -23,7 +23,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="acd5dbee-1b29-451c-9125-4dbb7fd3f4b2" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -31,7 +31,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="faa20e04-b929-4959-85f7-3c2788cce887" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -39,7 +39,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="3aa729cd-b693-4377-960d-bd0c3c217897" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -52,19 +52,19 @@
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
     </cpix:ContentKeyPeriodList>
     <cpix:ContentKeyUsageRuleList>
-        <cpix:ContentKeyUsageRule kid="873f3740-2508-4a2d-94bc-9b0f86649251" intendedTrackType="SD">
+        <cpix:ContentKeyUsageRule kid="cff143cc-f7ba-4f45-b7dc-11e789c70c1c" intendedTrackType="SD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="589824" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD">
+        <cpix:ContentKeyUsageRule kid="acd5dbee-1b29-451c-9125-4dbb7fd3f4b2" intendedTrackType="HD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="589825" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="STEREO_AUDIO">
+        <cpix:ContentKeyUsageRule kid="faa20e04-b929-4959-85f7-3c2788cce887" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO">
+        <cpix:ContentKeyUsageRule kid="3aa729cd-b693-4377-960d-bd0c3c217897" intendedTrackType="MULTICHANNEL_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3" />
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/3_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/3_fairplay.xml
@@ -1,42 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <cpix:CPIX contentId="test_case_5_6" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
-        <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
+        <cpix:ContentKey kid="cff143cc-f7ba-4f45-b7dc-11e789c70c1c"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+        <cpix:ContentKey kid="acd5dbee-1b29-451c-9125-4dbb7fd3f4b2"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
+        <cpix:ContentKey kid="faa20e04-b929-4959-85f7-3c2788cce887"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="80969196-fe0d-4c1b-aec3-522bebcbd61c"
+        <cpix:ContentKey kid="3aa729cd-b693-4377-960d-bd0c3c217897"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="cff143cc-f7ba-4f45-b7dc-11e789c70c1c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="acd5dbee-1b29-451c-9125-4dbb7fd3f4b2" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="faa20e04-b929-4959-85f7-3c2788cce887" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="3aa729cd-b693-4377-960d-bd0c3c217897" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
@@ -48,19 +48,19 @@
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
     </cpix:ContentKeyPeriodList>
     <cpix:ContentKeyUsageRuleList>
-        <cpix:ContentKeyUsageRule kid="873f3740-2508-4a2d-94bc-9b0f86649251" intendedTrackType="SD">
+        <cpix:ContentKeyUsageRule kid="cff143cc-f7ba-4f45-b7dc-11e789c70c1c" intendedTrackType="SD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="589824" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD">
+        <cpix:ContentKeyUsageRule kid="acd5dbee-1b29-451c-9125-4dbb7fd3f4b2" intendedTrackType="HD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="589825" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="STEREO_AUDIO">
+        <cpix:ContentKeyUsageRule kid="faa20e04-b929-4959-85f7-3c2788cce887" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO">
+        <cpix:ContentKeyUsageRule kid="3aa729cd-b693-4377-960d-bd0c3c217897" intendedTrackType="MULTICHANNEL_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3" />
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/4_widevine_playready.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/4_widevine_playready.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <cpix:CPIX contentId="test_case_5_6" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
-        <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
+        <cpix:ContentKey kid="cff143cc-f7ba-4f45-b7dc-11e789c70c1c"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+        <cpix:ContentKey kid="acd5dbee-1b29-451c-9125-4dbb7fd3f4b2"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
+        <cpix:ContentKey kid="faa20e04-b929-4959-85f7-3c2788cce887"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="80969196-fe0d-4c1b-aec3-522bebcbd61c"
+        <cpix:ContentKey kid="3aa729cd-b693-4377-960d-bd0c3c217897"
                          commonEncryptionScheme="cenc">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="cff143cc-f7ba-4f45-b7dc-11e789c70c1c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -23,7 +23,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="acd5dbee-1b29-451c-9125-4dbb7fd3f4b2" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -31,7 +31,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="faa20e04-b929-4959-85f7-3c2788cce887" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -39,7 +39,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="3aa729cd-b693-4377-960d-bd0c3c217897" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -47,7 +47,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="cff143cc-f7ba-4f45-b7dc-11e789c70c1c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -55,7 +55,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="acd5dbee-1b29-451c-9125-4dbb7fd3f4b2" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -63,7 +63,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="faa20e04-b929-4959-85f7-3c2788cce887" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -71,7 +71,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="3aa729cd-b693-4377-960d-bd0c3c217897" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -84,19 +84,19 @@
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
     </cpix:ContentKeyPeriodList>
     <cpix:ContentKeyUsageRuleList>
-        <cpix:ContentKeyUsageRule kid="873f3740-2508-4a2d-94bc-9b0f86649251" intendedTrackType="SD">
+        <cpix:ContentKeyUsageRule kid="cff143cc-f7ba-4f45-b7dc-11e789c70c1c" intendedTrackType="SD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="589824" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD">
+        <cpix:ContentKeyUsageRule kid="acd5dbee-1b29-451c-9125-4dbb7fd3f4b2" intendedTrackType="HD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="589825" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="STEREO_AUDIO">
+        <cpix:ContentKeyUsageRule kid="faa20e04-b929-4959-85f7-3c2788cce887" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO">
+        <cpix:ContentKeyUsageRule kid="3aa729cd-b693-4377-960d-bd0c3c217897" intendedTrackType="MULTICHANNEL_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3" />
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/5_widevine_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/5_widevine_fairplay.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <cpix:CPIX contentId="test_case_5_6" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
-        <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
+        <cpix:ContentKey kid="cff143cc-f7ba-4f45-b7dc-11e789c70c1c"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+        <cpix:ContentKey kid="acd5dbee-1b29-451c-9125-4dbb7fd3f4b2"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
+        <cpix:ContentKey kid="faa20e04-b929-4959-85f7-3c2788cce887"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="80969196-fe0d-4c1b-aec3-522bebcbd61c"
+        <cpix:ContentKey kid="3aa729cd-b693-4377-960d-bd0c3c217897"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="cff143cc-f7ba-4f45-b7dc-11e789c70c1c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -23,7 +23,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="acd5dbee-1b29-451c-9125-4dbb7fd3f4b2" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -31,7 +31,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="faa20e04-b929-4959-85f7-3c2788cce887" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -39,7 +39,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="3aa729cd-b693-4377-960d-bd0c3c217897" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -47,28 +47,28 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="cff143cc-f7ba-4f45-b7dc-11e789c70c1c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="acd5dbee-1b29-451c-9125-4dbb7fd3f4b2" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="faa20e04-b929-4959-85f7-3c2788cce887" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="3aa729cd-b693-4377-960d-bd0c3c217897" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
@@ -80,19 +80,19 @@
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
     </cpix:ContentKeyPeriodList>
     <cpix:ContentKeyUsageRuleList>
-        <cpix:ContentKeyUsageRule kid="873f3740-2508-4a2d-94bc-9b0f86649251" intendedTrackType="SD">
+        <cpix:ContentKeyUsageRule kid="cff143cc-f7ba-4f45-b7dc-11e789c70c1c" intendedTrackType="SD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="589824" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD">
+        <cpix:ContentKeyUsageRule kid="acd5dbee-1b29-451c-9125-4dbb7fd3f4b2" intendedTrackType="HD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="589825" maxPixels="2073600" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="STEREO_AUDIO">
+        <cpix:ContentKeyUsageRule kid="faa20e04-b929-4959-85f7-3c2788cce887" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO">
+        <cpix:ContentKeyUsageRule kid="3aa729cd-b693-4377-960d-bd0c3c217897" intendedTrackType="MULTICHANNEL_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3" />
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/6_playready_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/6_playready_fairplay.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <cpix:CPIX contentId="test_case_5_6" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
-        <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
+        <cpix:ContentKey kid="cff143cc-f7ba-4f45-b7dc-11e789c70c1c"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+        <cpix:ContentKey kid="acd5dbee-1b29-451c-9125-4dbb7fd3f4b2"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
+        <cpix:ContentKey kid="faa20e04-b929-4959-85f7-3c2788cce887"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="80969196-fe0d-4c1b-aec3-522bebcbd61c"
+        <cpix:ContentKey kid="3aa729cd-b693-4377-960d-bd0c3c217897"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="cff143cc-f7ba-4f45-b7dc-11e789c70c1c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -23,7 +23,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="acd5dbee-1b29-451c-9125-4dbb7fd3f4b2" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -31,7 +31,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="faa20e04-b929-4959-85f7-3c2788cce887" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -39,7 +39,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="3aa729cd-b693-4377-960d-bd0c3c217897" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -47,28 +47,28 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="cff143cc-f7ba-4f45-b7dc-11e789c70c1c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="acd5dbee-1b29-451c-9125-4dbb7fd3f4b2" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="faa20e04-b929-4959-85f7-3c2788cce887" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="3aa729cd-b693-4377-960d-bd0c3c217897" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
@@ -80,19 +80,19 @@
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
     </cpix:ContentKeyPeriodList>
     <cpix:ContentKeyUsageRuleList>
-        <cpix:ContentKeyUsageRule kid="873f3740-2508-4a2d-94bc-9b0f86649251" intendedTrackType="SD">
+        <cpix:ContentKeyUsageRule kid="cff143cc-f7ba-4f45-b7dc-11e789c70c1c" intendedTrackType="SD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="589824" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD">
+        <cpix:ContentKeyUsageRule kid="acd5dbee-1b29-451c-9125-4dbb7fd3f4b2" intendedTrackType="HD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="589825" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="STEREO_AUDIO">
+        <cpix:ContentKeyUsageRule kid="faa20e04-b929-4959-85f7-3c2788cce887" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO">
+        <cpix:ContentKeyUsageRule kid="3aa729cd-b693-4377-960d-bd0c3c217897" intendedTrackType="MULTICHANNEL_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3" />
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/7_widevine_playready_fairplay.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/test_case_5_and_6_p_v_2_a_2/7_widevine_playready_fairplay.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <cpix:CPIX contentId="test_case_5_6" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc">
     <cpix:ContentKeyList>
-        <cpix:ContentKey kid="873f3740-2508-4a2d-94bc-9b0f86649251"
+        <cpix:ContentKey kid="cff143cc-f7ba-4f45-b7dc-11e789c70c1c"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+        <cpix:ContentKey kid="acd5dbee-1b29-451c-9125-4dbb7fd3f4b2"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="f8a6640e-2938-45b1-a1ba-2b203c51530c"
+        <cpix:ContentKey kid="faa20e04-b929-4959-85f7-3c2788cce887"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
-        <cpix:ContentKey kid="80969196-fe0d-4c1b-aec3-522bebcbd61c"
+        <cpix:ContentKey kid="3aa729cd-b693-4377-960d-bd0c3c217897"
                          commonEncryptionScheme="cbcs">
         </cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="cff143cc-f7ba-4f45-b7dc-11e789c70c1c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -23,7 +23,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="acd5dbee-1b29-451c-9125-4dbb7fd3f4b2" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -31,7 +31,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="faa20e04-b929-4959-85f7-3c2788cce887" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -39,7 +39,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="3aa729cd-b693-4377-960d-bd0c3c217897" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -47,7 +47,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="cff143cc-f7ba-4f45-b7dc-11e789c70c1c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -55,7 +55,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="acd5dbee-1b29-451c-9125-4dbb7fd3f4b2" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -63,7 +63,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="faa20e04-b929-4959-85f7-3c2788cce887" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
              <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -71,7 +71,7 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
+        <cpix:DRMSystem kid="3aa729cd-b693-4377-960d-bd0c3c217897" systemId="9a04f079-9840-4286-ab92-e65be0885f95">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -79,28 +79,28 @@
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="873f3740-2508-4a2d-94bc-9b0f86649251" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="cff143cc-f7ba-4f45-b7dc-11e789c70c1c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="acd5dbee-1b29-451c-9125-4dbb7fd3f4b2" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="faa20e04-b929-4959-85f7-3c2788cce887" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
             <cpix:HLSSignalingData playlist="master">
             </cpix:HLSSignalingData>
         </cpix:DRMSystem>
-        <cpix:DRMSystem kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
+        <cpix:DRMSystem kid="3aa729cd-b693-4377-960d-bd0c3c217897" systemId="94ce86fb-07ff-4f43-adb8-93d2fa968ca2">
             <cpix:PSSH />
             <cpix:HLSSignalingData playlist="media">
             </cpix:HLSSignalingData>
@@ -112,19 +112,19 @@
         <cpix:ContentKeyPeriod id="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef" index="0"/>
     </cpix:ContentKeyPeriodList>
     <cpix:ContentKeyUsageRuleList>
-        <cpix:ContentKeyUsageRule kid="873f3740-2508-4a2d-94bc-9b0f86649251" intendedTrackType="SD">
+        <cpix:ContentKeyUsageRule kid="cff143cc-f7ba-4f45-b7dc-11e789c70c1c" intendedTrackType="SD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter maxPixels="589824" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="0c54f2b0-b433-45a4-ae73-664438bb0b4e" intendedTrackType="HD">
+        <cpix:ContentKeyUsageRule kid="acd5dbee-1b29-451c-9125-4dbb7fd3f4b2" intendedTrackType="HD">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:VideoFilter minPixels="589825" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="f8a6640e-2938-45b1-a1ba-2b203c51530c" intendedTrackType="STEREO_AUDIO">
+        <cpix:ContentKeyUsageRule kid="faa20e04-b929-4959-85f7-3c2788cce887" intendedTrackType="STEREO_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter maxChannels="2" />
         </cpix:ContentKeyUsageRule>
-        <cpix:ContentKeyUsageRule kid="80969196-fe0d-4c1b-aec3-522bebcbd61c" intendedTrackType="MULTICHANNEL_AUDIO">
+        <cpix:ContentKeyUsageRule kid="3aa729cd-b693-4377-960d-bd0c3c217897" intendedTrackType="MULTICHANNEL_AUDIO">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2e19ac38-22d3-4bb2-b290-95a72f4732ef"/>
             <cpix:AudioFilter minChannels="3" />
         </cpix:ContentKeyUsageRule>

--- a/spekev2_verification_testsuite/test_case_5_and_6_preset_2_unencrypted.py
+++ b/spekev2_verification_testsuite/test_case_5_and_6_preset_2_unencrypted.py
@@ -55,9 +55,8 @@ def widevine_playready_fairplay_response(spekev2_url):
 
 
 def test_case_5_widevine_preset_video_2_audio_unencrypted(widevine_response, spekev2_url):
-    xml_request = widevine_response.decode('UTF-8')
     response = utils.send_modified_speke_request_with_matching_elements_kid_values_removed(spekev2_url,
-                                                                                           xml_request.encode("UTF-8"),
+                                                                                           widevine_response,
                                                                                            elements_to_remove,
                                                                                            audio_kid)
 
@@ -76,9 +75,8 @@ def test_case_5_widevine_preset_video_2_audio_unencrypted(widevine_response, spe
 
 
 def test_case_5_widevine_playready_preset_video_2_audio_unencrypted(widevine_playready_response, spekev2_url):
-    xml_request = widevine_playready_response.decode('UTF-8')
     response = utils.send_modified_speke_request_with_matching_elements_kid_values_removed(spekev2_url,
-                                                                                           xml_request.encode("UTF-8"),
+                                                                                           widevine_playready_response,
                                                                                            elements_to_remove,
                                                                                            audio_kid)
     root_cpix = ET.fromstring(response.text)
@@ -95,9 +93,8 @@ def test_case_5_widevine_playready_preset_video_2_audio_unencrypted(widevine_pla
 
 
 def test_case_5_widevine_playready_fairplay_preset_video_2_audio_unencrypted(widevine_playready_fairplay_response, spekev2_url):
-    xml_request = widevine_playready_fairplay_response.decode('UTF-8')
     response = utils.send_modified_speke_request_with_matching_elements_kid_values_removed(spekev2_url,
-                                                                                           xml_request.encode("UTF-8"),
+                                                                                           widevine_playready_fairplay_response,
                                                                                            elements_to_remove,
                                                                                            audio_kid)
     root_cpix = ET.fromstring(response.text)
@@ -114,9 +111,8 @@ def test_case_5_widevine_playready_fairplay_preset_video_2_audio_unencrypted(wid
 
 
 def test_case_6_widevine_video_unencrypted_preset_audio_2(widevine_response, spekev2_url):
-    xml_request = widevine_response.decode('UTF-8')
     response = utils.send_modified_speke_request_with_matching_elements_kid_values_removed(spekev2_url,
-                                                                                           xml_request.encode("UTF-8"),
+                                                                                           widevine_response,
                                                                                            elements_to_remove,
                                                                                            video_kid)
     root_cpix = ET.fromstring(response.text)
@@ -133,9 +129,8 @@ def test_case_6_widevine_video_unencrypted_preset_audio_2(widevine_response, spe
 
 
 def test_case_6_widevine_playready_video_unencrypted_preset_audio_2(widevine_playready_response, spekev2_url):
-    xml_request = widevine_playready_response.decode('UTF-8')
     response = utils.send_modified_speke_request_with_matching_elements_kid_values_removed(spekev2_url,
-                                                                                           xml_request.encode("UTF-8"),
+                                                                                           widevine_playready_response,
                                                                                            elements_to_remove,
                                                                                            video_kid)
     root_cpix = ET.fromstring(response.text)
@@ -152,9 +147,8 @@ def test_case_6_widevine_playready_video_unencrypted_preset_audio_2(widevine_pla
 
 
 def test_case_6_widevine_playready_fairplay_video_unencrypted_preset_audio_2(widevine_playready_fairplay_response, spekev2_url):
-    xml_request = widevine_playready_fairplay_response.decode('UTF-8')
     response = utils.send_modified_speke_request_with_matching_elements_kid_values_removed(spekev2_url,
-                                                                                           xml_request.encode("UTF-8"),
+                                                                                           widevine_playready_fairplay_response,
                                                                                            elements_to_remove,
                                                                                            video_kid)
     root_cpix = ET.fromstring(response.text)

--- a/spekev2_verification_testsuite/test_case_5_and_6_preset_2_unencrypted.py
+++ b/spekev2_verification_testsuite/test_case_5_and_6_preset_2_unencrypted.py
@@ -9,13 +9,13 @@ elements_to_remove = [
 ]
 
 video_kid = [
-    "873f3740-2508-4a2d-94bc-9b0f86649251",
-    "0c54f2b0-b433-45a4-ae73-664438bb0b4e"
+    "cff143cc-f7ba-4f45-b7dc-11e789c70c1c",
+    "acd5dbee-1b29-451c-9125-4dbb7fd3f4b2"
 ]
 
 audio_kid = [
-    "f8a6640e-2938-45b1-a1ba-2b203c51530c",
-    "80969196-fe0d-4c1b-aec3-522bebcbd61c"
+    "faa20e04-b929-4959-85f7-3c2788cce887",
+    "3aa729cd-b693-4377-960d-bd0c3c217897"
 ]
 
 
@@ -55,8 +55,7 @@ def widevine_playready_fairplay_response(spekev2_url):
 
 
 def test_case_5_widevine_preset_video_2_audio_unencrypted(widevine_response, spekev2_url):
-    xml_request = widevine_response.decode('UTF-8') \
-                    .replace("test_case_5_6", "test_case_5")
+    xml_request = widevine_response.decode('UTF-8')
     response = utils.send_modified_speke_request_with_matching_elements_kid_values_removed(spekev2_url,
                                                                                            xml_request.encode("UTF-8"),
                                                                                            elements_to_remove,
@@ -77,8 +76,7 @@ def test_case_5_widevine_preset_video_2_audio_unencrypted(widevine_response, spe
 
 
 def test_case_5_widevine_playready_preset_video_2_audio_unencrypted(widevine_playready_response, spekev2_url):
-    xml_request = widevine_playready_response.decode('UTF-8') \
-                    .replace("test_case_5_6", "test_case_5")
+    xml_request = widevine_playready_response.decode('UTF-8')
     response = utils.send_modified_speke_request_with_matching_elements_kid_values_removed(spekev2_url,
                                                                                            xml_request.encode("UTF-8"),
                                                                                            elements_to_remove,
@@ -97,8 +95,7 @@ def test_case_5_widevine_playready_preset_video_2_audio_unencrypted(widevine_pla
 
 
 def test_case_5_widevine_playready_fairplay_preset_video_2_audio_unencrypted(widevine_playready_fairplay_response, spekev2_url):
-    xml_request = widevine_playready_fairplay_response.decode('UTF-8') \
-        .replace("test_case_5_6", "test_case_5")
+    xml_request = widevine_playready_fairplay_response.decode('UTF-8')
     response = utils.send_modified_speke_request_with_matching_elements_kid_values_removed(spekev2_url,
                                                                                            xml_request.encode("UTF-8"),
                                                                                            elements_to_remove,
@@ -117,8 +114,7 @@ def test_case_5_widevine_playready_fairplay_preset_video_2_audio_unencrypted(wid
 
 
 def test_case_6_widevine_video_unencrypted_preset_audio_2(widevine_response, spekev2_url):
-    xml_request = widevine_response.decode('UTF-8') \
-                    .replace("test_case_5_6", "test_case_6")
+    xml_request = widevine_response.decode('UTF-8')
     response = utils.send_modified_speke_request_with_matching_elements_kid_values_removed(spekev2_url,
                                                                                            xml_request.encode("UTF-8"),
                                                                                            elements_to_remove,
@@ -137,8 +133,7 @@ def test_case_6_widevine_video_unencrypted_preset_audio_2(widevine_response, spe
 
 
 def test_case_6_widevine_playready_video_unencrypted_preset_audio_2(widevine_playready_response, spekev2_url):
-    xml_request = widevine_playready_response.decode('UTF-8') \
-                    .replace("test_case_5_6", "test_case_6")
+    xml_request = widevine_playready_response.decode('UTF-8')
     response = utils.send_modified_speke_request_with_matching_elements_kid_values_removed(spekev2_url,
                                                                                            xml_request.encode("UTF-8"),
                                                                                            elements_to_remove,
@@ -157,8 +152,7 @@ def test_case_6_widevine_playready_video_unencrypted_preset_audio_2(widevine_pla
 
 
 def test_case_6_widevine_playready_fairplay_video_unencrypted_preset_audio_2(widevine_playready_fairplay_response, spekev2_url):
-    xml_request = widevine_playready_fairplay_response.decode('UTF-8') \
-                    .replace("test_case_5_6", "test_case_6")
+    xml_request = widevine_playready_fairplay_response.decode('UTF-8')
     response = utils.send_modified_speke_request_with_matching_elements_kid_values_removed(spekev2_url,
                                                                                            xml_request.encode("UTF-8"),
                                                                                            elements_to_remove,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Generated new key IDs for every test case. Avoid key ID collisions as key IDs usually must be unique for a key provider and cannot be reused for other content ID/track type combinations.
1. Use unique content IDs where collisions would occur. Avoid replacing `test_case_5_6` with `test_case_5` or `test_case_6`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
