### PR TITLE
verification test suite - unique key IDs

### DIFF
--- a/spekev2_verification_testsuite/spekev2_requests/general/2_speke_v1_style_implementation.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/general/2_speke_v1_style_implementation.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="test_case_speke_v1_style_request" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:enc="http://www.w3.org/2001/04/xmlenc#">
+<cpix:CPIX contentId="test_case_speke_v1_style_request_general" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:enc="http://www.w3.org/2001/04/xmlenc#">
     <cpix:ContentKeyList>
-        <cpix:ContentKey kid="0f083e4e-b831-4a3d-917e-ce78076e1234" commonEncryptionScheme="cenc"></cpix:ContentKey>
+        <cpix:ContentKey kid="d4ab38f0-530e-4baa-85a0-d54e075bde74" commonEncryptionScheme="cenc"></cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
-        <cpix:DRMSystem kid="0f083e4e-b831-4a3d-917e-ce78076e1234" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="d4ab38f0-530e-4baa-85a0-d54e075bde74" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -17,7 +17,7 @@
         <cpix:ContentKeyPeriod id="keyPeriod_2a50937e-4f6d-4794-9e77-f9ed86d4443c" index="0" />
     </cpix:ContentKeyPeriodList>
     <cpix:ContentKeyUsageRuleList>
-        <cpix:ContentKeyUsageRule kid="0f083e4e-b831-4a3d-917e-ce78076e1234" intendedTrackType="ALL">
+        <cpix:ContentKeyUsageRule kid="d4ab38f0-530e-4baa-85a0-d54e075bde74" intendedTrackType="ALL">
             <cpix:KeyPeriodFilter periodId="keyPeriod_2a50937e-4f6d-4794-9e77-f9ed86d4443c" />
             <cpix:VideoFilter />
             <cpix:AudioFilter />

--- a/spekev2_verification_testsuite/spekev2_requests/vod/2_speke_v1_style_implementation.xml
+++ b/spekev2_verification_testsuite/spekev2_requests/vod/2_speke_v1_style_implementation.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cpix:CPIX contentId="test_case_speke_v1_style_request" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:enc="http://www.w3.org/2001/04/xmlenc#">
+<cpix:CPIX contentId="test_case_speke_v1_style_request_vod" version="2.3" xmlns:cpix="urn:dashif:org:cpix" xmlns:pskc="urn:ietf:params:xml:ns:keyprov:pskc" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:enc="http://www.w3.org/2001/04/xmlenc#">
     <cpix:ContentKeyList>
-        <cpix:ContentKey kid="0f083e4e-b831-4a3d-917e-ce78076e1234" commonEncryptionScheme="cenc"></cpix:ContentKey>
+        <cpix:ContentKey kid="7442b8bb-9a82-4836-bdb7-d6a16bb828d0" commonEncryptionScheme="cenc"></cpix:ContentKey>
     </cpix:ContentKeyList>
     <cpix:DRMSystemList>
-        <cpix:DRMSystem kid="0f083e4e-b831-4a3d-917e-ce78076e1234" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cpix:DRMSystem kid="7442b8bb-9a82-4836-bdb7-d6a16bb828d0" systemId="edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
             <cpix:PSSH />
             <cpix:ContentProtectionData />
             <cpix:HLSSignalingData playlist="media">
@@ -14,7 +14,7 @@
         </cpix:DRMSystem>
     </cpix:DRMSystemList>
     <cpix:ContentKeyUsageRuleList>
-        <cpix:ContentKeyUsageRule kid="0f083e4e-b831-4a3d-917e-ce78076e1234" intendedTrackType="ALL">
+        <cpix:ContentKeyUsageRule kid="7442b8bb-9a82-4836-bdb7-d6a16bb828d0" intendedTrackType="ALL">
             <cpix:VideoFilter />
             <cpix:AudioFilter />
         </cpix:ContentKeyUsageRule>


### PR DESCRIPTION
*Issue #, if available:*

n/a

*Description of changes:*

Support DRM systems that enforce unique key IDs.

Some DRM systems require unique key IDs as well as unique combinations of contentId + intendedTrackType + periodId.

Issues would occur if key IDs are reused across test cases, but for different combinations. In the case of the speke-v1-style test once *with* key period and once *without* key period. This change addresses this specific issue by updating the contentId as well as the key IDs. Key IDs were randomly generated.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
