### PR TITLE
Add MediaPackage v2 service principal to the reference Invoke SPEKE Role

### DIFF
--- a/cloudformation/speke_reference.json
+++ b/cloudformation/speke_reference.json
@@ -472,7 +472,8 @@
                         "Effect": "Allow",
                         "Principal": {
                             "Service": [
-                                "mediapackage.amazonaws.com"
+                                "mediapackage.amazonaws.com",
+                                "mediapackagev2.amazonaws.com"
                             ]
                         },
                         "Action": [


### PR DESCRIPTION
*Description of changes:*

This enables the reference Invoke SPEKE Role to be used with MediaPackage v2

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
