### PR TITLE
Fix value checked by test_sending_same_request_sent_twice_to_keyserver_without_key_rotati

### DIFF
--- a/spekev2_verification_testsuite/test_basic_checks.py
+++ b/spekev2_verification_testsuite/test_basic_checks.py
@@ -89,7 +89,7 @@ def test_speke_v2_elements_have_not_changed(basic_response):
 
 def test_sending_same_request_sent_twice_to_keyserver_without_key_rotation(duplicate_responses):
     test_responses = [response.replace("\n", "").replace("\r", "") for response in duplicate_responses]
-    regex_pattern = "<pskc:PlainValue>(.*)</pskc:PlainValue>(.*)<pskc:PlainValue>(.*)</pskc:PlainValue>"
+    regex_pattern = "<(.*):PlainValue>(.*)</(.*):PlainValue>(.*)<(.*):PlainValue>(.*)</(.*):PlainValue>"
     results = []
     for response in test_responses:
         results.append(re.search(regex_pattern, response))

--- a/spekev2_verification_testsuite/test_basic_checks.py
+++ b/spekev2_verification_testsuite/test_basic_checks.py
@@ -95,7 +95,7 @@ def test_sending_same_request_sent_twice_to_keyserver_without_key_rotation(dupli
         results.append(re.search(regex_pattern, response))
 
     if results[0] is not None:
-        assert results[0].group(1) == results[1].group(1) and results[0].group(3) == results[1].group(3), \
+        assert results[0].group(2) == results[1].group(2) and results[0].group(6) == results[1].group(6), \
             "Keys returned for duplicate responses must be the same with key rotation turned off"
     else:
         assert False, \

--- a/spekev2_verification_testsuite/test_check_mandatory_elements.py
+++ b/spekev2_verification_testsuite/test_check_mandatory_elements.py
@@ -13,12 +13,12 @@ def basic_response(spekev2_url, test_suite_dir):
 
 
 def test_cpix_root_in_response(basic_response):
-    required_namespaces = utils.SPEKE_V2_MANDATORY_NAMESPACES
-    namespaces_in_response = dict([node for _, node in ET.iterparse(StringIO(basic_response), events=['start-ns'])])
+    required_namespaces = utils.SPEKE_V2_MANDATORY_NAMESPACES.values()
+    namespaces_in_response = dict([node for _, node in ET.iterparse(StringIO(basic_response), events=['start-ns'])]).values()
 
     # Validate if required namespaces are present in the response
     assert all(ns in namespaces_in_response for ns in required_namespaces), \
-        f"Requred namespaces must be present in response: {utils.SPEKE_V2_MANDATORY_NAMESPACES}"
+        f"Requred namespaces must be present in response: {required_namespaces}"
 
     root_cpix = ET.fromstring(basic_response)
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/speke-reference-server/issues/102

*Description of changes:*
Regex was changed, assertions need to be fixed too

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
