### PR TITLE
Remove join function which appends region to S3 bucket name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ The following page guides the user through deployment and configuration of the S
 1. In `zappa_settings.json` under `src`, replace `aws_region` with the region this lambda will be deployed.
 1. Run `local_build.sh`. If you are working on Mac/Windows, run the script with `REQUIRES_SPEKE_SERVER_LAMBDA_LAYER=true` to generate `speke-libs` lambda layer zip file. Note that Docker is required to build the zip file. See the [sidenote](#sidenote-building-the-lambda-on-macwindows) below for more details about the lambda layer.
 1. The script will generate required artifacts under `build` folder.
-1. Create a new bucket in S3 (For example: `speke-us-east-1`). Create a folder called `speke` and upload the generated `speke-reference` lambda zip file. If you build with `REQUIRES_SPEKE_SERVER_LAMBDA_LAYER=true`, upload the generated `speke-libs` lambda layer zip file to the same folder too. 
-1. In the generated `speke_reference.json`, replace `rodeolabz` with the name of your created bucket (`speke` is used in this example).
+1. Create a new bucket in S3 (For example: `speke-bucket`). Create a folder called `speke` and upload the generated `speke-reference` lambda zip file. If you build with `REQUIRES_SPEKE_SERVER_LAMBDA_LAYER=true`, upload the generated `speke-libs` lambda layer zip file to the same folder too. 
+1. In the generated `speke_reference.json`, replace `rodeolabz` with the name of your created bucket (`speke-bucket` is used in this example).
 1. Use the `speke_reference.json` template in CloudFormation to deploy the speke reference server following the instructions below.
 
 #### **Sidenote:** Building the lambda on Mac/Windows

--- a/cloudformation/speke_reference.json
+++ b/cloudformation/speke_reference.json
@@ -168,16 +168,7 @@
             "Condition": "RequiresSPEKEServerLambdaLayer",
             "Properties": {
                 "Content": {
-                    "S3Bucket" : {
-                        "Fn::Join": [
-                            "-", [
-                                "rodeolabz",
-                                {
-                                    "Ref": "AWS::Region"
-                                }
-                            ]
-                        ]
-                    },
+                    "S3Bucket" : "rodeolabz",
                     "S3Key": "speke/speke-libs-DEV_0_0_0.zip"
                 }
             }
@@ -186,16 +177,7 @@
             "Type": "AWS::Lambda::Function",
             "Properties": {
                 "Code": {
-                    "S3Bucket": {
-                        "Fn::Join": [
-                            "-", [
-                                "rodeolabz",
-                                {
-                                    "Ref": "AWS::Region"
-                                }
-                            ]
-                        ]
-                    },
+                    "S3Bucket": "rodeolabz",
                     "S3Key": "speke/speke-reference-lambda-DEV_0_0_0.zip"
                 },
                 "Layers": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The released version requires the user to create an S3 bucket in order to deploy the lambda however the cloudformation template then appends this s3 bucket name with the region the code is deployed in.  This is not made clear in the documentation.  There is no good reason to do this and the lack of clarity in the readme means that this can be a blocker to deploying the code.

cloudformation/speke_reference.json - removed join function which appends the S3 bucket name with the region.
Updated readme.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
